### PR TITLE
demo-image-full: add cuda-libraries

### DIFF
--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-full.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-full.bb
@@ -11,4 +11,4 @@ REQUIRED_DISTRO_FEATURES = "x11 opengl virtualization"
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-x11tests"
 CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'packagegroup-demo-vulkantests', '', d)}"
-CORE_IMAGE_BASE_INSTALL += "libvisionworks-devso-symlink nvidia-docker tegra-mmapi-samples"
+CORE_IMAGE_BASE_INSTALL += "libvisionworks-devso-symlink nvidia-docker cuda-libraries tegra-mmapi-samples"


### PR DESCRIPTION
since the Deepstream 5 Docker container needs CUDA
libraries not already pulled in by other packages.

Signed-off-by: Matt Madison <matt@madison.systems>