### PR TITLE
base-files: add RRECOMMENDS on kernel-module-overlay

### DIFF
--- a/layers/meta-tegrademo/recipes-core/base-files/base-files_%.bbappend
+++ b/layers/meta-tegrademo/recipes-core/base-files/base-files_%.bbappend
@@ -3,3 +3,4 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 dirs755_append_tegrademo-mender = " /data"
 
 RDEPENDS_${PN}_append_tegrademo-mender = " data-overlay-setup"
+RRECOMMENDS_${PN}_append_tegrademo-mender = " kernel-module-overlay"


### PR DESCRIPTION
For tegrademo-mender builds, we add overlay mounts
to fstab, so add the overlay module as a runtime
recommendation.

Signed-off-by: Matt Madison <matt@madison.systems>