### PR TITLE
Contributor guide and pre-commit hook script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ package is located.
 
         $ . ./setup-env --help
 
+4. Optional: Install pre-commit hook for commit autosigning using
+        $ ./scripts-setup/setup-pre-commit-hook.sh
+
 ## Distributions
 
 Use the `--distro` option with `setup-env` to specify a distribution for your build,

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ package is located.
         $ . ./setup-env --help
 
 4. Optional: Install pre-commit hook for commit autosigning using
-        $ ./scripts-setup/setup-pre-commit-hook.sh
+        $ ./scripts-setup/setup-git-hooks
 
 ## Distributions
 
@@ -75,3 +75,9 @@ demo applications.
 | demo-image-sato   | X11 image with Sato UI                                        |
 | demo-image-weston | Wayland with Weston compositor                                |
 | demo-image-full   | Sato image plus nvidia-docker, openCV, multimedia API samples |
+
+# Contributing
+
+Please see the contributor wiki page at [this link](https://github.com/OE4T/meta-tegra/wiki/OE4T-Contributor-Guide).
+Contributions are welcome!
+

--- a/scripts-setup/git-scripts/prepare-commit-msg
+++ b/scripts-setup/git-scripts/prepare-commit-msg
@@ -1,0 +1,15 @@
+#/bin/sh
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+     --in-place "$1" 
+

--- a/scripts-setup/setup-git-hooks
+++ b/scripts-setup/setup-git-hooks
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+BASEDIR=$(git rev-parse --show-toplevel)
+SCRIPTDIR=$(dirname $0)
+for GITHOOKDIR in ${BASEDIR}/.git/hooks ${BASEDIR}/.git/modules/repos/*/hooks
+do
+    for GITHOOK in ${SCRIPTDIR}/git-scripts/*
+    do
+        GITHOOKFILE=$(basename $GITHOOK)
+        if [ -e ${GITHOOKDIR}/${GITHOOKFILE} ]; then
+            echo "A git hook file aleady exists at ${GITHOOKDIR}/${GITHOOKFILE}, leaving as-is"
+        else
+            echo "Adding ${GITHOOKFILE} to ${GITHOOKDIR}"
+            cp ${GITHOOK} ${GITHOOKDIR}
+            chmod a+x ${GITHOOKDIR}/${GITHOOKFILE}
+        fi
+    done
+done


### PR DESCRIPTION
Per discussion in the monthly meeting, add a contributor guide and update the README.

Add a pre-commit hook setup script for automated git signoff to correspond to contributor guide requirements.

See work in progress [contributor guide wiki page](https://github.com/OE4T/meta-tegra/wiki/OE4T-Contributor-Guide)

I'll make a similar README change on meta-tegra referencing the contributor guide when this PR is merged.