### PR TITLE
packagegroup-demo-vulkantests: drop vulkan-demos

### DIFF
--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-vulkantests.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-vulkantests.bb
@@ -5,6 +5,5 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS_${PN} = " \
-    vulkan-demos \
     vulkan-tools \
 "


### PR DESCRIPTION
which has been dropped from OE-Core.

Signed-off-by: Matt Madison <matt@madison.systems>

Fixes #23 