### PR TITLE
setup-env-internal: Support custom distro location

### DIFF
--- a/scripts-setup/setup-env-internal
+++ b/scripts-setup/setup-env-internal
@@ -6,16 +6,12 @@ PROGNAME=$(basename "$SETUP_SCRIPT")
 SETUP_SCRIPTDIR=$(dirname "$SETUP_SCRIPT")
 TD_TOP="${TD_TOP:-$(readlink -f $SETUP_SCRIPTDIR)}"
 
-DISTRO_LAYERS="meta-tegrademo"
 DISTRO_DEFAULT="tegrademo"
 BUILDDIR_DEFAULT="build"
 
 distro_list() {
-    local d paths
-    
-    for d in $DISTRO_LAYERS; do
-	paths="$paths $TD_TOP/layers/$d/conf/distro"
-    done
+    local paths
+    paths=$(find -L $TD_TOP/layers/ -path '*meta-*/conf/distro/*' -name '*.conf')
     find $paths -maxdepth 1 -name '*.conf' | xargs basename -s .conf | sort -u | awk '{print "\t" $0}'
 }
 


### PR DESCRIPTION
With the change at https://github.com/OE4T/tegra-demo-distro/commit/a5b816f2009e4a407ab7c89b793d647095347a64
we are now validating distros are available before allowing them to
be used.  This highlights a limitation with distro selection only
being allowed in predetermined directories, rather than supporting
redefining in any meta- sublayer.

Modify to support custom distros defined in proprietary layers.

Signed-off-by: Dan Walkes <danwalkes@boulderai.com>