### PR TITLE
Add meta-demo-ci layer

### DIFF
--- a/layers/meta-demo-ci/classes/mirror_updates.bbclass
+++ b/layers/meta-demo-ci/classes/mirror_updates.bbclass
@@ -1,0 +1,167 @@
+# Class for automatically populating downloads and/or sstate mirrors
+# during builds, when the mirrors are separate from the normal, local
+# DL_DIR and SSTATE_DIR used to perform the build.
+#
+# Supports file:// and s3:// URLs.
+# S3 support also requires the lib/oeaws/s3session.py module.
+
+# For updating the downloads mirror:
+#  - set UPDATE_DOWNLOADS_MIRROR to "1" and
+#  - set DOWNLOADS_MIRROR_URL to the URL for the mirror
+# You should also set BB_GENERATE_MIRROR_TARBALLS to "1" so
+# that tarballs of any SCM repositories get uploaded to the
+# mirror.
+UPDATE_DOWNLOADS_MIRROR ?= "0"
+DOWNLOADS_MIRROR_URL ??= ""
+
+# For updating the shared state mirror:
+#  - set UPDATE_SSTATE_MIROR to "1" and
+#  - set SSTATE_MIRROR_URL to the URL for the mirror
+UPDATE_SSTATE_MIRROR ?= "0"
+SSTATE_MIRROR_URL ??= ""
+
+python downloads_mirror_update() {
+    import os, shutil, urllib.parse
+
+    src_uri = (d.getVar("SRC_URI") or "").split()
+    if len(src_uri) == 0:
+        return
+
+    mirror = urllib.parse.urlparse(d.getVar("DOWNLOADS_MIRROR_URL"))
+
+    s3 = None
+    if mirror.scheme == 's3':
+        from oeaws import s3session
+        s3 = s3session.S3Session()
+    elif mirror.scheme != 'file':
+        bb.warn("unsupported DOWNLOADS_MIRROR_URL type: %s" % mirror.scheme)
+        return
+    fetcher = bb.fetch2.Fetch(src_uri, d)
+    dl_dir = d.getVar("DL_DIR")
+    for url in src_uri:
+        # We don't mirror when the SRC_URI is a file://, since those
+        # aren't actually downloaded
+        if urllib.parse.urlparse(url).scheme == 'file':
+            continue
+        if hasattr(fetcher.ud[url], 'fullmirror'):
+            localfile = fetcher.ud[url].fullmirror
+        else:
+            localfile = fetcher.localpath(url)
+        # Only files get mirrored, not directories
+        if not os.path.exists(localfile) or os.path.isdir(localfile):
+            continue
+        remotefile = localfile[len(dl_dir)+1:]
+        if not s3:
+            # When mirroring to the local filesystem, don't mirror symlinks
+            if os.path.islink(localfile):
+                continue
+            mirrorfile = os.path.join(mirror.path, remotefile)
+            bb.utils.mkdirhier(os.path.dirname(mirrorfile))
+            lf = bb.utils.lockfile("%s.lock" % mirrorfile)
+            try:
+                bb.debug(1, "copying: %s -> %s" % (localfile, mirrorfile))
+                shutil.copyfile(localfile, mirrorfile)
+            except IOError:
+                bb.warn("error copying %s to %s" % (localfile, mirrorfile))
+            bb.utils.unlockfile(lf)
+        else:
+            mirrorpath = mirror.path.split('/')
+            mirrorpath.append(remotefile)
+            destobj = '/'.join(mirrorpath[1:])
+            info = s3.get_object_info(mirror.netloc, destobj)
+            if info and 'LastModified' in info:
+                mtime = int(time.mktime(info['LastModified'].timetuple()))
+                st = os.stat(localfile)
+                if info['ContentLength'] == st.st_size and int(st.st_mtime) == mtime:
+                    continue
+            s3.upload(localfile, mirror.netloc, destobj)
+}
+
+python sstate_mirror_update() {
+    import os, shutil, urllib.parse
+
+    if d.getVar('SSTATE_SKIP_CREATION') == '1':
+        return
+
+    mirror = urllib.parse.parseurl(d.getVar("SSTATE_MIRROR_URL"))
+    if mirror.scheme == 'file':
+        sstatepkg = d.getVar("SSTATE_PKG")
+        mirrorpkg = os.path.join(mirror.path, d.getVar("SSTATE_PKGNAME"))
+        bb.utils.mkdirhier(os.path.dirname(mirrorpkg))
+        lf = bb.utils.lockfile("%s.lock" % mirrorpkg)
+        try:
+            bb.debug(1, "copying: %s -> %s" % (sstatepkg, mirrorpkg))
+            shutil.copyfile(sstatepkg, mirrorpkg)
+            shutil.copyfile(sstatepkg + ".siginfo", mirrorpkg + ".siginfo")
+        except IOError:
+            bb.warn("error copying %s to %s" % (sstatepkg, mirrorpkg))
+        bb.utils.unlockfile(lf)
+    elif mirror.scheme == 's3'
+        from oeaws import s3session
+
+        mirrorpath = mirror.path.split('/')
+        mirrorpath.append(d.getVar("SSTATE_PKGNAME"))
+        sstatepkg = d.getVar("SSTATE_PKG")
+        destobj = '/'.join(mirrorpath[1:])
+        s3 = s3session.S3Session()
+        s3.upload(sstatepkg, mirror.netloc, destobj)
+        s3.upload(sstatepkg + ".siginfo", mirror.netloc, destobj + ".siginfo")
+    else:
+        bb.warn("unsupported SSTATE_MIRROR_URL type: %s" % mirror.scheme)
+}
+
+
+python () {
+    import os, urllib.parse
+
+    try:
+        from oeaws import s3session
+    except ImportError:
+        pass
+
+    if bb.utils.to_boolean(d.getVar("UPDATE_DOWNLOADS_MIRROR")):
+        mirror = urllib.parse.urlparse(d.getVar("DOWNLOADS_MIRROR_URL"))
+        enable = False
+        if mirror.scheme == 'file':
+            if os.access(mirror.path, os.W_OK):
+                enable = True
+            else:
+                bb.warn("DOWNLOADS_MIRROR_URL (%s) not writable" % mirror.path)
+        elif mirror.scheme == 's3':
+            if s3session:
+                enable = True
+            else:
+                bb.warn("UPDATE_DOWNLOADS_MIRROR enabled but s3session module cannot be loaded")
+        else:
+            bb.warn("UPDATE_DOWNLOADS_MIRROR enabled, but DOWNLOADS_MIRROR_URL not file:// or s3:// URL")
+
+        if enable:
+            postfuncs = (d.getVarFlag("do_fetch", "postfuncs") or "").split()
+            if "downloads_mirror_update" not in postfuncs:
+                d.appendVarFlag("do_fetch", "postfuncs", " downloads_mirror_update")
+                d.appendVarFlag("do_fetch", "vardepsexclude", " downloads_mirror_update")
+
+    if bb.utils.to_boolean(d.getVar("UPDATE_SSTATE_MIRROR")):
+        enable = False
+        mirror = urllib.parse.urlparse(d.getVar("SSTATE_MIRROR_URL"))
+        if mirror.scheme == 'file':
+            if os.access(mirror.path, os.W_OK):
+                enable = True
+            else:
+                bb.warn("SSTATE_MIRROR_URL (%s) not writable, skipping updates" % mirror.path)
+        elif mirror.scheme == 's3':
+            if s3session:
+                enable = True
+            else:
+                bb.warn("UPDATE_SSTATE_MIRROR enabled but s3session module cannot be loaded")
+        else:
+            bb.warn("UPDATE_SSTATE_MIRROR enabled, but SSTATE_MIRROR_URL not file:// or s3:// URL")
+
+        if enable:
+            for task in (d.getVar("SSTATETASKS") or "").split():
+                postfuncs = (d.getVarFlag(task, "postfuncs") or "").split()
+                if "sstate_task_postfunc" in postfuncs and "sstate_mirror_update" not in postfuncs:
+                    d.appendVarFlag(task, "postfuncs", " sstate_mirror_update")
+                    d.appendVarFlag(task, "vardepsexclude", " sstate_mirror_update")
+
+}

--- a/layers/meta-demo-ci/conf/layer.conf
+++ b/layers/meta-demo-ci/conf/layer.conf
@@ -1,0 +1,11 @@
+BBPATH =. "${LAYERDIR}:"
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "tegrademo-ci"
+BBFILE_PATTERN_tegrademo-ci = "^${LAYERDIR}/"
+BBFILE_PATTERN_IGNORE_EMPTY_tegrademo-ci = "1"
+BBFILE_PRIORITY_tegrademo-ci = "40"
+
+LAYERVERSION_tegrademo-ci = "1"
+LAYERDEPENDS_tegrademo-ci = "core"
+LAYERSERIES_COMPAT_tegrademo-ci = "gatesgarth"

--- a/layers/meta-demo-ci/lib/oeaws/botos3fetcher.py
+++ b/layers/meta-demo-ci/lib/oeaws/botos3fetcher.py
@@ -1,0 +1,64 @@
+# ex:ts=4:sw=4:sts=4:et
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
+"""
+BitBake fetcher for AWS S3 using boto3
+
+Makes direct boto3 API calls for S3 fetches for improved
+performance over the built-in awscli-based fetcher.
+
+You must have the boto3 and botocore packages, and their
+dependencies, installed prior to use.
+
+
+Copyright (c) 2019-2020, Matthew Madison <matt@madison.systems>
+"""
+
+import os
+import bb
+
+awsvars = [ 'AWS_CONFIG_FILE',
+            'AWS_PROFILE',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_SHARED_CREDENTIALS_FILE',
+            'AWS_SESSION_TOKEN',
+            'AWS_DEFAULT_REGION',
+            'AWS_METADATA_SERVICE_NUM_ATTEMPTS',
+            'AWS_METADATA_SERVICE_TIMEOUT']
+
+class S3(bb.fetch2.s3.S3):
+
+    def __init__(self, urls=None):
+        super().__init__(urls)
+        self.session = oeaws.s3session.S3Session()
+
+    def fix_env(self, d):
+        origenv = d.getVar('BB_ORIGENV', False)
+        for v in awsvars:
+            val = os.getenv(v)
+            if val:
+                bb.debug(2, "Have %s=%s in env" % (v, val))
+                continue
+            val = origenv and origenv.getVar(v)
+            if val:
+                os.environ[v] = val
+                bb.debug(2, 'Set %s=%s in env' % (v, val))
+            bb.debug(2, 'No setting for %s' % v)
+
+    def checkstatus(self, fetch, ud, d):
+        self.fix_env(d)
+        return self.session.get_object_info(ud.host, ud.path[1:]) is not None
+
+    def download(self, ud, d):
+        self.fix_env(d)
+        if not self.session.download(ud.host, ud.path[1:], ud.localpath):
+            raise bb.fetch2.FetchError("could not download s3://%s%s" % (ud.host, ud.path))
+        return True
+
+try:
+    import oeaws.s3session
+    bb.fetch2.methods = [m for m in bb.fetch2.methods if not isinstance(m, bb.fetch2.s3.S3)] + [S3()]
+    bb.debug(1, "botos3fetcher: installed")
+except:
+    bb.debug(1, "botos3fetcher: s3session import failed")
+    pass

--- a/layers/meta-demo-ci/lib/oeaws/s3session.py
+++ b/layers/meta-demo-ci/lib/oeaws/s3session.py
@@ -1,0 +1,114 @@
+# ex:ts=4:sw=4:sts=4:et
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
+"""
+AWS S3 session management using boto3/botocore.
+
+Speeds up S3 fetcher operations by directly calling boto3
+APIs.  Can also be used for S3 uploads.
+
+Remember to whitelist any AWS_* environment variables you
+may need to use for S3 access during builds.
+
+Copyright (c) 2019-2020, Matthew Madison <matt@madison.systems>
+"""
+
+import os
+import time
+import random
+import bb
+import boto3
+import botocore
+
+def s3retry_wait(trynumber):
+    time.sleep(random.SystemRandom().random() * (trynumber * 5.0) + 5.0)
+
+class S3Session(object):
+    def __init__(self, maxtries=10):
+        self.s3client = None
+        default_maxtries = os.getenv('AWS_METADATA_SERVICE_NUM_ATTEMPTS')
+        if default_maxtries is not None and int(default_maxtries) > maxtries:
+            self.maxtries = int(default_maxtries)
+        else:
+            self.maxtries = maxtries
+        default_timeout = os.getenv('AWS_METADATA_SERVICE_TIMEOUT')
+        if default_timeout is not None and int(default_timeout) > 1:
+            self.metadata_timeout = int(default_timeout)
+        else:
+            self.metadata_timeout = 10
+
+    def makeclient(self):
+        os.environ['AWS_METADATA_SERVICE_NUM_ATTEMPTS'] = '{}'.format(self.maxtries)
+        os.environ['AWS_METADATA_SERVICE_TIMEOUT'] = '{}'.format(self.metadata_timeout)
+        session = botocore.session.get_session()
+        self.s3client = boto3.Session(botocore_session=session).client('s3')
+        provider = session.get_component('credential_provider').get_provider('assume-role')
+        provider.cache = botocore.credentials.JSONFileCache()
+        bb.debug(1, "Using AWS profile: %s" % provider._profile_name)
+
+    def upload(self, Filename, Bucket, Key):
+        if self.s3client is None:
+            self.makeclient()
+        for attempt in range(self.maxtries):
+            try:
+                self.s3client.upload_file(Bucket=Bucket, Key=Key, Filename=Filename)
+            except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError):
+                s3tretry_wait(attempt)
+                continue
+            except botocore.exceptions.ClientError as e:
+                err = e.repsonse['Error']
+                bb.warn("{}/{}: {} {}".format(Bucket, Key, err['Code'], err['Message']))
+                return False
+            return True
+        bb.warn("{}/{}: credentials error on upload for 10 attempts".format(Bucket, Key))
+        return False
+
+    def download(self, Bucket, Key, Filename, quiet=True):
+        if self.s3client is None:
+            self.makeclient()
+        for attempt in range(10):
+            try:
+                bb.debug(2, "%s/%s: attempt %d" % (Bucket, Key, attempt))
+                info = self.s3client.head_object(Bucket=Bucket, Key=Key)
+                self.s3client.download_file(Bucket=Bucket, Key=Key, Filename=Filename)
+                if 'LastModified' in info:
+                    mtime = int(time.mktime(info['LastModified'].timetuple()))
+                    os.utime(Filename, (mtime, mtime))
+            except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError):
+                s3retry_wait(attempt)
+                continue
+            except botocore.exceptions.ClientError as e:
+                err = e.response['Error']
+                if quiet and err['Code'] == "404":
+                    bb.debug(2, "not found: {}/{}".format(Bucket, Key))
+                else:
+                    bb.warn("{}/{}: {} {}".format(Bucket, Key, err['Code'], err['Message']))
+                return False
+            except OSError as e:
+                if quiet:
+                    pass
+                bb.warn("os.utime({}): {} (errno {})".format(Filename, e.strerror, e.errno))
+                return False
+            bb.debug(1, "{}/{}: success".format(Bucket, Key))
+            return True
+        bb.warn("{}/{}: credentials error on download for 10 attempts".format(Bucket, Key))
+        return False
+
+    def get_object_info(self, Bucket, Key, quiet=True):
+        if self.s3client is None:
+            self.makeclient()
+        for attempt in range(10):
+            try:
+                info = self.s3client.head_object(Bucket=Bucket, Key=Key)
+            except botocore.exceptions.NoCredentialsError:
+                s3retry_wait(attempt)
+                continue
+            except botocore.exceptions.ClientError as e:
+                err = e.response['Error']
+                if quiet and err['Code'] == "404":
+                    bb.debug(2, "not found: {}/{}".format(Bucket, Key))
+                else:
+                    bb.warn("{}/{}: {} {}".format(Bucket, Key, err['Code'], err['Message']))
+                return None
+            return info
+        bb.warn("{}/{}: credentials error on get_object_info for 10 attempts".format(Bucket, Key))
+        return None

--- a/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
@@ -1,5 +1,5 @@
 include tegrademo.conf
-REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-3"
+REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-4"
 
 DISTRO = "tegrademo-mender"
 DISTRO_NAME = "OE4Tegra Demonstration Distro with Mender"

--- a/layers/meta-tegrademo/conf/distro/tegrademo.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo.conf
@@ -14,7 +14,7 @@ TARGET_VENDOR = "-oe4t"
 # Increment version number (and the corresponding
 # setting int the template bblayers.conf.sample file)
 # each time the layer settings are changed.
-REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-2"
+REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-3"
 
 LOCALCONF_VERSION = "1"
 

--- a/layers/meta-tegrademo/conf/template-tegrademo-mender/bblayers.conf.sample
+++ b/layers/meta-tegrademo/conf/template-tegrademo-mender/bblayers.conf.sample
@@ -1,7 +1,7 @@
 # Version of layers configuration, specific to
 # each defined distro in the repository.
 # Format: ${DISTRO}-<version>
-TD_BBLAYERS_CONF_VERSION = "tegrademo-mender-3"
+TD_BBLAYERS_CONF_VERSION = "tegrademo-mender-4"
 
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""
@@ -18,6 +18,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-mender-core \
   ##OEROOT##/meta-mender-tegra \
   ##OEROOT##/meta-tegra-support \
+  ##OEROOT##/meta-demo-ci \
   ##OEROOT##/meta-tegrademo \
   "
 

--- a/layers/meta-tegrademo/conf/template-tegrademo/bblayers.conf.sample
+++ b/layers/meta-tegrademo/conf/template-tegrademo/bblayers.conf.sample
@@ -1,7 +1,7 @@
 # Version of layers configuration, specific to
 # each defined distro in the repository.
 # Format: ${DISTRO}-<version>
-TD_BBLAYERS_CONF_VERSION = "tegrademo-2"
+TD_BBLAYERS_CONF_VERSION = "tegrademo-3"
 
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""
@@ -16,5 +16,6 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-filesystems \
   ##OEROOT##/meta-virtualization \
   ##OEROOT##/meta-tegra-support \
+  ##OEROOT##/meta-demo-ci \
   ##OEROOT##/meta-tegrademo \
   "


### PR DESCRIPTION
with a bbclass and some library modules to support the CI autobuilder in AWS.

The layer gets added to the layer set, but requires extra configuration to use; otherwise it has no effect.  The extra configuration is added as part of the autobuilder setup.