### PR TITLE
Switch from NVIDIA bootloader tools to tegra-boot-tools

### DIFF
--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -1,0 +1,38 @@
+#!/bin/sh
+quiet=
+if [ "$1" = "-n" ]; then
+    quiet="yes"
+    shift
+    if [ -z "$1" ]; then
+        echo "ERR: missing var name with -n" >&2
+        exit 1
+    fi
+fi
+if [ -z "$1" ]; then
+    echo "mender_boot_part=`tegra-boot-control --current-slot`"
+    exit 0
+fi
+while [ -n "$1" ]; do
+    case "$1" in
+        mender_boot_part|mender_boot_part_hex)
+            [ -n "$quiet" ] || echo -n "$1="
+            tegra-boot-control --current-slot
+            ;;
+        mender_uboot_separator)
+            [ -n "$quiet" ] || echo -n "$1="
+            echo "something other than just 1"
+            ;;
+        upgrade_available)
+            [ -n "$quiet" ] || echo -n "$1="
+	    if [ -e "/var/lib/mender/upgrade_available" ]; then
+		echo "1"
+	    else
+		echo "0"
+	    fi
+           ;;
+        *)
+           echo "ERR: no such variable: $1" >&2
+           exit 1
+    esac
+    shift
+done

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake_%.bbappend
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+RDEPENDS_${PN} += "tegra-boot-tools"

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-core/initrdscripts/tegra-minimal-init/platform-preboot-cboot.sh
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-core/initrdscripts/tegra-minimal-init/platform-preboot-cboot.sh
@@ -1,0 +1,23 @@
+slotsfx=""
+mayberoot=""
+for bootarg in `cat /proc/cmdline`; do
+    case "$bootarg" in
+	boot.slot_suffix=*) slotsfx="${bootarg##boot.slot_suffix=}" ;;
+	root=*) mayberoot="${bootarg##root=}" ;;
+	ro) opt="ro" ;;
+	rootwait) wait="yes" ;;
+    esac
+done
+rootdev=`blkid -l -t PARTLABEL=APP$slotsfx | cut -d: -f1`
+if [ -z "$rootdev" ]; then
+    if [ -n "$mayberoot" ]; then
+	rootdev="$mayberoot"
+    else
+	rootdev="/dev/mmcblk0p1"
+    fi
+fi
+
+if which bootcountcheck >/dev/null 2>&1; then
+    bootcountcheck
+fi
+

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-core/initrdscripts/tegra-minimal-init_%.bbappend
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-core/initrdscripts/tegra-minimal-init_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+EXTRADEPS = ""
+EXTRADEPS_tegra = "tegra-boot-tools-earlyboot"
+EXTRADEPS_tegra210 = ""
+RDEPENDS_${PN} += "${EXTRADEPS}"

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
@@ -1,4 +1,4 @@
 EXTRADEPS = ""
-EXTRADEPS_tegra = "tegra-boot-tools"
+EXTRADEPS_tegra = "tegra-boot-tools tegra-boot-tools-nvbootctrl tegra-boot-tools-lateboot"
 EXTRADEPS_tegra210 = ""
 RDEPENDS_${PN} += "${EXTRADEPS}"

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-commit-check-script-uboot
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-commit-check-script-uboot
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+LABELCHARS="AB"
+
+echo "Verifying Tegra bootloader update"
+curslot=`tegra-boot-control --current-slot`
+cfglbl="\"RootfsPart${LABELCHARS:$curslot:1}\""
+devnam=`grep -h "$cfglbl:" /etc/mender/mender.conf /var/lib/mender/mender.conf | cut -d: -f2 | cut -d, -f1 | tr -d '" '`
+if [ -z "$devnam" ]; then
+    echo "ERR: could not determine expected mender device name for boot slot $curslot" >&2
+    exit 1
+fi
+
+# If the rootfs partitions are eMMC/SDcard device names, verify that
+# the mender boot partition in U-Boot and the Tegra bootloader boot
+# slot match.  If not, the Tegra bootloader update failed, and we
+# need to reset the boot slot to get the Tegra bootloader and Mender
+# resynchronized.
+if [ "${devnam##/dev/mmcblk}" != "${devnam}" ]; then
+    bootpart=`fw_printenv -n mender_boot_part`
+    if [ -z "$bootpart" ]; then
+	echo "ERR: could not retrieve mender_boot_part from U-Boot env" >&2
+	exit 1
+    fi
+    devnampart=`expr "${devnam##/dev/mmcblk*p}" \+ 0 2>/dev/null`
+    if [ -z "$devnampart" ]; then
+	echo "ERR: could not extract partition number from rootfs device name" >&2
+	exit 1
+    fi
+    if [ $bootpart -ne $devnampart ]; then
+	altslot=$(expr 1 - $curslot)
+	echo "Detected Tegra bootloader upgrade failure, resetting boot slot to $altslot" >&2
+	echo "*** Reboot required ***" >&2
+	tegra-boot-control --set-active $altslot
+	exit 1
+    fi
+fi
+exit 0

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
@@ -1,8 +1,6 @@
 #!/bin/sh
 
 mnt=
-LABELCHARS="AB"
-COPY_MACHINE_ID=@COPY_MACHINE_ID@
 
 cleanup() {
     [ -n "$mnt" ] || return
@@ -19,25 +17,13 @@ cleanup() {
 
 echo "Installing NVIDIA bootloader update payload"
 
-if which tegra-boot-control >/dev/null 2>&1; then
-    current_slot=`tegra-boot-control --current-slot`
-else
-    current_slot=`nvbootctrl get-current-slot`
-fi
-echo "Current boot slot: $current_slot"
-otherslot=`expr 1 - $current_slot`
-cfglbl="\"RootfsPart${LABELCHARS:$otherslot:1}\""
-devnam=`grep -h "$cfglbl:" /etc/mender/mender.conf /var/lib/mender/mender.conf | cut -d: -f2 | cut -d, -f1 | tr -d '" '`
-if [ -z "$devnam" ]; then
-    echo "ERR: could not determine device name for boot slot $otherslot" >&2
-    exit 1
-fi
+new_boot_part=`fw_printenv -n mender_boot_part`
 mnt=`mktemp -d -t nvbup.XXXXXX`
 if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
-mount "$devnam" "$mnt"
+mount /dev/mmcblk0p${new_boot_part} "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2
     cleanup
@@ -54,13 +40,5 @@ if ! chroot "${mnt}" /usr/bin/tegra-bootloader-update /opt/ota_package/bl_update
     exit 1
 fi
 echo "Successful bootloader update"
-if [ -n "$COPY_MACHINE_ID" ]; then
-    curid=$(systemd-machine-id-setup --print)
-    storedid=$(chroot "${mnt}" /usr/bin/tegra-bootinfo -n -v machine_id 2>/dev/null)
-    if [ "$curid" != "$storedid" ]; then
-	chroot "${mnt}" /usr/bin/tegra-bootinfo --initialize 2>/dev/null
-	chroot "${mnt}" /usr/bin/tegra-bootinfo -V machine_id "$curid"
-    fi
-fi
 cleanup
 exit 0

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/tegra-state-scripts/tegra-state-scripts_%.bbappend
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-mender/tegra-state-scripts/tegra-state-scripts_%.bbappend
@@ -1,1 +1,20 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_remove = "file://redundant-boot-rollback-script-uboot"
+
+copy_install_script() {
+    sed -e's,@COPY_MACHINE_ID@,${PERSIST_MACHINE_ID},' ${S}/redundant-boot-install-script > ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_80_bl-update
+}
+
+copy_install_script_mender-uboot() {
+    cp ${S}/redundant-boot-install-script-uboot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_80_bl-update
+    cp ${S}/redundant-boot-commit-check-script-uboot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_80_bl-check-update
+}
+
+copy_other_scripts() {
+    :
+}
+
+do_compile_tegra210() {
+    cp ${S}/redundant-boot-install-script-uboot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_80_bl-update
+}

--- a/layers/meta-tegra-support/recipes-bsp/tegra-bup-payload/tegra-bup-payload_%.bbappend
+++ b/layers/meta-tegra-support/recipes-bsp/tegra-bup-payload/tegra-bup-payload_%.bbappend
@@ -1,0 +1,2 @@
+RDEPENDS_${PN}_remove = "tegra-redundant-boot"
+RDEPENDS_${PN}_append = " tegra-boot-tools-updater"


### PR DESCRIPTION
For Mender builds, replace the tegra-redundant-boot tools from the L4T BSP with [tegra-boot-tools](https://github.com/OE4T/tegra-boot-tools):
* Update the Mender state scripts to use the new tools
* For cboot platforms, add bootcount check to initramfs and boot-success marking to normal rootfs using the utilities/services provided by tegra-boot-tools 
* Update runtime dependencies where needed to switch to the new tools

After this update:
* The `tegra-boot-control` utility replaces `nvbootctrl`.  An emulation script for `nvbootctrl` is added to handle downgrades (since the downloaded state scripts assume `nvbootctrl` is available).
*  The `tegra-bootloader-update` utility replaces `nv_update_engine` (and no `nv_update_verifier` service is installed) on cboot platforms, and replaces `l4t_payload_updater_t210` on the TX1/Nano.
* Boot count status can be viewed with `tegra-bootinfo --show` on cboot platforms.
* The `/etc/nv_boot_control.conf` file is no longer present, since the new tools don't need it; they instead directly read the information they need from the hardware.
* Bootloader updates on Xavier NX modules/devkits should take about half the time when BUP contents match what's already present in the QSPI flash, since the new tools only write updates when the contents are different.
