### PR TITLE
Updates for the Nano 2GB dev kit for tegrademo-mender

### DIFF
--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-2gb-devkit/flash_mender.xml
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-2gb-devkit/flash_mender.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0"?>
+
+<!-- Nvidia Tegra Partition Layout Version 1.0.0 -->
+
+<partition_layout version="01.00.0000">
+    <device type="spi" instance="0">
+        <partition name="BCT" type="boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains Boot Configuration Table (BCT). </description>
+        </partition>
+
+        <partition name="NXC" type="NVCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> NVCFILE </filename>
+            <description> **Required.** Contains TegraBoot binary. </description>
+        </partition>
+
+        <partition name="PT" type="partition_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> flash.xml.bin </filename>
+            <description> **Required.** Contains Partition Table. </description>
+        </partition>
+
+        <partition name="NXC_R" type="NVCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> NVCFILE </filename>
+            <description> **Required.** Contains a redundant copy of the TegraBoot
+              binary. </description>
+        </partition>
+
+        <partition name="UBENV" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+	    <start_location> 0x3B0000 </start_location>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> U-Boot environment area  </description>
+        </partition>
+
+        <partition name="VER_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+	    <start_location> 0x3E0000 </start_location>
+            <size> 32768 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> VERFILE </filename>
+            <description>  **Required.** Contains a redundant copy of BSP version
+              information. </description>
+        </partition>
+
+        <partition name="VER" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+	    <start_location> 0x3F0000 </start_location>
+            <size> 32768 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> VERFILE </filename>
+            <description>  **Required.** Contains BSP version information. </description>
+        </partition>
+
+    </device>
+    <device type="sdcard" instance="0">
+        <partition name="GP1" type="GP1">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains primary GPT of the `sdcard` device. All
+              partitions defined after this entry are configured in the kernel, and are accessible
+              by standard partition tools such as gdisk and parted. </description>
+        </partition>
+
+        <partition name="APP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> APPSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <align_boundary> 4096 </align_boundary>
+            <filename> APPFILE </filename>
+            <description> **Required.** Contains the rootfs. This partition must be defined after
+              `primary_GPT` so that it can be accessed as the fixed known special device
+              `/dev/mmcblk0p1`. </description>
+        </partition>
+
+        <partition name="TXC" type="TBCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+            <description> **Required.** Contains TegraBoot CPU-side binary. </description>
+        </partition>
+
+        <partition name="RP1" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTBFILE </filename>
+            <description> **Required.** Contains Bootloader DTB binary. </description>
+        </partition>
+
+        <partition name="EBT" type="bootloader">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 589824 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EBTFILE </filename>
+            <description> **Required.** Contains CBoot, the final boot stage CPU bootloader
+              binary that loads the binary in the kernel partition.. </description>
+        </partition>
+
+        <partition name="WX0" type="WB0TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0FILE </filename>
+            <description> **Required.** Contains warm boot binary. </description>
+        </partition>
+
+        <partition name="BXF" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+            <description> **Required.** Contains SC7 entry firmware. </description>
+        </partition>
+
+        <partition name="BXF-DTB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 393216 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB-FILE </filename>
+            <description> **Optional.** Reserved for future use by BPMP DTB binary; can't remove. </description>
+        </partition>
+
+        <partition name="FX" type="FBTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FBFILE </filename>
+            <description> **Optional.** Reserved for fuse bypass; removeable. </description>
+        </partition>
+
+        <partition name="TXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+            <description> **Required.** Contains TOS binary. </description>
+        </partition>
+
+        <partition name="DXB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTBFILE </filename>
+            <description> **Required.** Contains kernel DTB binary. </description>
+        </partition>
+
+        <partition name="LNX" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 786432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> LNXFILE </filename>
+            <description> **Required.** Contains U-Boot, which loads and launches the kernel from
+              the rootfs at `/boot`. </description>
+        </partition>
+
+        <partition name="EXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+            <description> **Optional.** Contains the encrypted keys. </description>
+        </partition>
+
+        <partition name="BMP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 81920 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+            <description> **Optional.** Contains BMP images for splash screen display during
+              boot. </description>
+        </partition>
+
+        <partition name="RP4" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> rp4.blob </filename>
+            <description> **Required.** Contains XUSB module’s firmware file, making XUSB
+              a true USB 3.0 compliant host controller. </description>
+        </partition>
+
+        <partition name="APP_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> APPSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <align_boundary> 4096 </align_boundary>
+            <filename> APPFILE </filename>
+        </partition>
+
+        <partition name="SWAP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4294967296 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <align_boundary> 4096 </align_boundary>
+        </partition>
+
+        <partition name="UDA" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <allocation_attribute> 0x808 </allocation_attribute>
+            <filename> DATAFILE </filename>
+        </partition>
+
+        <partition name="GPT" type="GPT">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains secondary GPT of the `sdcard` device. </description>
+        </partition>
+    </device>
+</partition_layout>

--- a/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
@@ -37,3 +37,9 @@ MENDER_STORAGE_TOTAL_SIZE_MB ?= "${@tegra_mender_calc_total_size(d) - int(d.getV
 SYSTEMD_DEFAULT_TARGET = "finished-booting.target"
 
 IMAGE_INSTALL_append_tegra = " tegra-eeprom-tool i2c-tools tegra-bup-payload"
+
+# Added a swap partition for the Nano 2GB dev kit, bumping the
+# data partition number.
+MENDER_DATA_PART_NUMBER_DEFAULT_jetson-nano-2gb-devkit = "17"
+# 5046 = 950 (default from above) plus 4096 for the swap partition
+TEGRA_FLASH_PARTITIONS_MB_jetson-nano-2gb-devkit = "5046"

--- a/layers/meta-tegrademo/recipes-core/base-files/base-files/tegrademo-mender/fstab-swap
+++ b/layers/meta-tegrademo/recipes-core/base-files/base-files/tegrademo-mender/fstab-swap
@@ -1,0 +1,1 @@
+PARTLABEL=SWAP	none	swap	nofail,x-systemd.makefs,x-systemd.device-timeout=60s

--- a/layers/meta-tegrademo/recipes-core/base-files/base-files_%.bbappend
+++ b/layers/meta-tegrademo/recipes-core/base-files/base-files_%.bbappend
@@ -1,6 +1,13 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
+SRC_URI_append_tegrademo-mender_jetson-nano-2gb-devkit = " file://fstab-swap"
+
 dirs755_append_tegrademo-mender = " /data"
 
+do_install_append_tegrademo-mender_jetson-nano-2gb-devkit() {
+    cat ${WORKDIR}/fstab-swap >>${D}${sysconfdir}/fstab
+}
+
 RDEPENDS_${PN}_append_tegrademo-mender = " data-overlay-setup"
+RDEPENDS_${PN}_append_tegrademo-mender_jetson-nano-2gb-devkit = " util-linux-mkswap util-linux-swaponoff"
 RRECOMMENDS_${PN}_append_tegrademo-mender = " kernel-module-overlay"


### PR DESCRIPTION
This patch series fixes the build issues for `jetson-nano-2gb-devkit` machines for the tegrademo-mender distro.

A flash layout specific to the Nano-2GB is added.  It's identical to the regular Nano devkit layout, with the addition of a swap partition (NV recommends adding swap space for any AI/ML work with the Nano 2GB).  The swap space is set up via an fstab entry.

Mender settings for the target are adjusted to account for the additional partition.