### PR TITLE
Rework Nano U-Boot environment for Mender builds

### DIFF
--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-2gb-devkit/flash_mender.xml
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-2gb-devkit/flash_mender.xml
@@ -143,13 +143,37 @@
         <partition name="LNX" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 753664 </size>
+            <size> 720896 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> LNXFILE </filename>
             <description> **Required.** Contains U-Boot, which loads and launches the kernel from
               the rootfs at `/boot`. </description>
+        </partition>
+
+        <partition name="EXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+            <description> **Optional.** Contains the encrypted keys. </description>
+        </partition>
+
+        <partition name="BMP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+            <description> **Optional.** Contains BMP images for splash screen display during
+              boot. </description>
         </partition>
 
         <partition name="RP4" type="data">
@@ -167,8 +191,8 @@
         <partition name="UBENV" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-	    <start_location> 0x3B0000 </start_location>
-            <size> 131072 </size>
+	    <start_location> 0x3D0000 </start_location>
+            <size> 65536 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-devkit/flash_mender.xml
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-devkit/flash_mender.xml
@@ -143,13 +143,37 @@
         <partition name="LNX" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 753664 </size>
+            <size> 720896 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> LNXFILE </filename>
             <description> **Required.** Contains U-Boot, which loads and launches the kernel from
               the rootfs at `/boot`. </description>
+        </partition>
+
+        <partition name="EXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+            <description> **Optional.** Contains the encrypted keys. </description>
+        </partition>
+
+        <partition name="BMP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+            <description> **Optional.** Contains BMP images for splash screen display during
+              boot. </description>
         </partition>
 
         <partition name="RP4" type="data">
@@ -167,8 +191,8 @@
         <partition name="UBENV" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-	    <start_location> 0x3B0000 </start_location>
-            <size> 131072 </size>
+	    <start_location> 0x3D0000 </start_location>
+            <size> 65536 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/patches/0016-Update-env-for-SPIflash-Nanos-for-R32.5.0-with-Mende.patch
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/patches/0016-Update-env-for-SPIflash-Nanos-for-R32.5.0-with-Mende.patch
@@ -1,0 +1,52 @@
+From 05f033868f7e8fdece13fa2861a5bda1f433ed23 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 7 Feb 2021 08:45:33 -0800
+Subject: [PATCH] Update env for SPIflash Nanos for R32.5.0 with Mender
+
+Need to move the environment area and reduce its
+size in order to fit redundant copies between RP4
+and VER_b.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ configs/p3450-0000_defconfig | 6 +++---
+ configs/p3541-0000_defconfig | 6 +++---
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/configs/p3450-0000_defconfig b/configs/p3450-0000_defconfig
+index 0fe9b5fb52..9907eaedb8 100644
+--- a/configs/p3450-0000_defconfig
++++ b/configs/p3450-0000_defconfig
+@@ -60,9 +60,9 @@ CONFIG_USB_XHCI_TEGRA=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_DOS_PARTITION=y
+ CONFIG_CMD_CACHE=y
+-CONFIG_ENV_SIZE=0x10000
+-CONFIG_ENV_OFFSET=0x3b0000
+-CONFIG_ENV_OFFSET_REDUND=0x3c0000
++CONFIG_ENV_SIZE=0x8000
++CONFIG_ENV_OFFSET=0x3d0000
++CONFIG_ENV_OFFSET_REDUND=0x3d8000
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ # CONFIG_ENV_IS_NOWHERE is not set
+ # CONFIG_ENV_IS_IN_EEPROM is not set
+diff --git a/configs/p3541-0000_defconfig b/configs/p3541-0000_defconfig
+index 708e6d0398..4443cd9a7f 100644
+--- a/configs/p3541-0000_defconfig
++++ b/configs/p3541-0000_defconfig
+@@ -1,9 +1,9 @@
+ CONFIG_ARM=y
+ CONFIG_ARCH_TEGRA=y
+ CONFIG_SYS_TEXT_BASE=0x80080000
+-CONFIG_ENV_SIZE=0x10000
+-CONFIG_ENV_OFFSET=0x3b0000
+-CONFIG_ENV_OFFSET_REDUND=0x3c0000
++CONFIG_ENV_SIZE=0x8000
++CONFIG_ENV_OFFSET=0x3d0000
++CONFIG_ENV_OFFSET_REDUND=0x3d8000
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_ENV_SECT_SIZE=0x1000
+ CONFIG_NR_DRAM_BANKS=16
+-- 
+2.27.0
+

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -1,1 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"

--- a/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_2020.10.bbappend
+++ b/layers/meta-tegra-support/dynamic-layers/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_2020.10.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 SRC_URI_append_mender-uboot = " file://0012-p3541-0000_defconfig-Mender-patch.patch"
 # XXX --- Temporary until these changes go upstream
 SRC_URI_append_mender-uboot = " file://0015-Update-TX1-nano-emmc-defconfigs-for-new-UBENV-locati.patch"
+SRC_URI_append_mender-uboot = " file://0016-Update-env-for-SPIflash-Nanos-for-R32.5.0-with-Mende.patch"
 
-MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_tegra210 = "${@'3866624' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '3801088'}"
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_tegra210 = "${@'3997696' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '3801088'}"
 # --- XXX

--- a/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
@@ -45,3 +45,6 @@ MENDER_ROOTFS_PART_B_NUMBER_jetson-nano-devkit = "2"
 # Swap is in partition 3 on the 2GB devkit
 MENDER_DATA_PART_NUMBER_jetson-nano-2gb-devkit = "4"
 MENDER_ROOTFS_PART_B_NUMBER_jetson-nano-2gb-devkit = "2"
+# Overrides until meta-mender-tegra is updated
+BOOTENV_SIZE_jetson-nano-devkit = "0x8000"
+BOOTENV_SIZE_jetson-nano-2gb-devkit = "0x8000"


### PR DESCRIPTION
For Nano devkits (both 4GB and 2GB), update the layout of the SPI flash:
* Reduce the size of the LNX partition by 32KiB
* Move the UBENV partition to 0x3D0000
* Reduce the U-Boot environment size to 32KiB
* Restore the EKS and BMP partitions that were omitted during the original R32.5.0 integration

This allows us to fit all of the boot partitions and the redundant U-Boot environment areas into the SPI flash.  Since our U-Boot build is only around 640KiB in size, we still have around 60KiB of room for future growth with the smaller LNX size.  The 32KiB U-Boot environment size also provides plenty of room for growth, since our default environment is only around 6Kib.

Fixes #43