### PR TITLE
scripts: Add deploy and setup udev rules script

### DIFF
--- a/layers/meta-tegrademo/scripts/oe4t-tegraflash-deploy
+++ b/layers/meta-tegrademo/scripts/oe4t-tegraflash-deploy
@@ -1,0 +1,80 @@
+#! /bin/sh
+set -e
+
+PROGNAME=$(basename $0)
+
+usage()
+{
+    cat >&2 <<EOF
+Deploy a tegraflash image to a machine connected via local USB
+and in recovery mode.
+Usage: $PROGNAME --machine <MACHINE> --image <IMAGE>
+Options:
+    -h, --h             Print this usage message
+    -m, --machine       Set the MACHINE used for this script
+    -i, --image         Set the IMAGE used for this script
+Examples:
+- To deploy a demo-image-base image for jetson-xavier-nx-devkit machine:
+  $ $0 --machine jetson-xavier-nx-devkit  --image demo-image-base
+EOF
+}
+
+# get command line options
+SHORTOPTS="hm:i:"
+LONGOPTS="help,machine:,image:"
+
+ARGS=$(getopt --options $SHORTOPTS --longoptions $LONGOPTS --name $PROGNAME -- "$@" )
+if [ $? != 0 ]; then
+   usage
+   exit 1
+fi
+
+eval set -- "$ARGS"
+while true;
+do
+    case $1 in
+        -h | --help)       usage; exit 0 ;;
+        -m | --machine)    MACHINE="$2"; shift 2;;
+        -i | --image)      IMAGE="$2"; shift 2;;
+        -- )               shift; break ;;
+        * )                break ;;
+    esac
+done
+
+if [ -z "$MACHINE" ]; then
+    echo "You must specify a machine"
+    usage
+    exit 1
+fi
+
+if [ -z "$IMAGE" ]; then
+    echo "You must specify an image"
+    usage
+    exit 1
+fi
+
+echo "Using machine ${MACHINE} image ${IMAGE}"
+deployfile=${IMAGE}-${MACHINE}.tegraflash.tar.gz
+scriptdir=$(realpath $(dirname $0))
+tmpdir=`mktemp`
+rm -rf $tmpdir
+mkdir -p $tmpdir
+echo "Using temp directory $tmpdir"
+currentdir=$(realpath .)
+cd $tmpdir
+cp $scriptdir/../../../build/tmp/deploy/images/${MACHINE}/$deployfile .
+tar -xvf $deployfile
+set +e
+./doflash.sh
+rc=$?
+if [ $rc -ne 0 ]; then
+    if [ ! -e /etc/udev/rules.d/??-oe4t.rules ]; then
+        echo "No rules file exists and flash failed."
+        echo "You may need to run setup-udev-rules"
+        echo "Or run this script as root"
+    fi
+fi
+cd $currentdir
+echo "Removing temp directory $tmpdir"
+rm -rf $tmpdir
+exit $rc

--- a/layers/meta-tegrademo/scripts/setup-udev-rules
+++ b/layers/meta-tegrademo/scripts/setup-udev-rules
@@ -1,0 +1,39 @@
+#!/bin/sh
+if [ "$(id -u)" -ne 0 ]; then
+    echo "You may need to run this script as sudo if you see permission errors"
+fi
+if [ ! -z "${SUDO_USER}" ]; then
+    user=${SUDO_USER}
+else
+    user=`whoami`
+fi
+set -e
+cat << EOF > /etc/udev/rules.d/99-oe4t.rules
+# Jetson TK1
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7140", GROUP="plugdev"
+# Jetson TX1
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7721", GROUP="plugdev"
+# Jetson TX2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7c18", GROUP="plugdev"
+# Jetson TX2i
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7018", GROUP="plugdev"
+# Jetson TX2-4GB
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7418", GROUP="plugdev"
+# Jetson AGX Xavier
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7019", GROUP="plugdev"
+# Jetson Xavier NX
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7e19", GROUP="plugdev"
+# Jetson Nano
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7f21", GROUP="plugdev"
+EOF
+udevadm control --reload
+echo "udev settings applied, please disconnect/reconnect your device"
+set +e
+groups ${user} | grep "plugdev" > /dev/null 2>&1
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "Please add ${user} to plugdev using:"
+    echo "sudo usermod -a -G plugdev  ${user}"
+    echo "Then apply to your user by logging back into the session or running"
+    echo "newgrp plugdev"
+fi


### PR DESCRIPTION
Move the deploy script out of meta mender community, clean
it up to have arguments and not require running under sudo.

Move the steps from the https://github.com/OE4T/meta-tegra/wiki/Flashing-the-Jetson-Dev-Kit
page into a `setup-udev-rules` script and reference this if
deploy fails.

Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>