### PR TITLE
Dunfell+oe4t deploy scripts + cboot default on R32.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ Currently supported distributions are listed below:
 | tegrademo         | Default distro used to demonstrate/test meta-tegra features   |
 | tegrademo-mender  | Adds [mender](https://www.mender.io/) OTA support             |
 
+### tegrademo-mender
+
+The tegrademo-mender distro demonstrates [mender](https://www.mender.io/) OTA update
+support with customizations on the tegrademo distribution including:
+
+1. Dual A/B rootfs support with read-only-rootfs.
+2. Integration with cboot and [tegra-boot-tools](https://github.com/OE4T/tegra-boot-tools)
+ to support persistent systemd machine-id settings on read only rootfs.
+3. Boot slot and rootfs partition synchronization through boot tools and bootloader
+integration.
+
+The synchronization of boot slot and root filesystem partition is more complicated to
+manage and test with via u-boot (see [this issue](https://github.com/BoulderAI/meta-mender-community/pull/1#issue-516955713)
+for detail).  For this reason, the tegrademo-mender distribution defaults to use the
+cboot bootloader on Jetson TX2, instead of the default u-boot bootloader used by
+meta-tegra.  If you need to use a different bootloader you can customize the setting
+of `PREFERRED_PROVIDER_virtual/bootloader_tegra186` in your distro layer.
 
 ## Images
 

--- a/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
@@ -36,3 +36,6 @@ MENDER_STORAGE_TOTAL_SIZE_MB ?= "${@tegra_mender_calc_total_size(d) - int(d.getV
 SYSTEMD_DEFAULT_TARGET = "finished-booting.target"
 
 IMAGE_INSTALL_append_tegra = " tegra-eeprom-tool i2c-tools tegra-bup-payload"
+
+# Use cboot by default on TX2 to avoid uboot slot alignment issues
+PREFERRED_PROVIDER_virtual/bootloader_tegra186 = "cboot-t18x"

--- a/layers/meta-tegrademo/scripts/oe4t-tegraflash-deploy
+++ b/layers/meta-tegrademo/scripts/oe4t-tegraflash-deploy
@@ -1,0 +1,80 @@
+#! /bin/sh
+set -e
+
+PROGNAME=$(basename $0)
+
+usage()
+{
+    cat >&2 <<EOF
+Deploy a tegraflash image to a machine connected via local USB
+and in recovery mode.
+Usage: $PROGNAME --machine <MACHINE> --image <IMAGE>
+Options:
+    -h, --h             Print this usage message
+    -m, --machine       Set the MACHINE used for this script
+    -i, --image         Set the IMAGE used for this script
+Examples:
+- To deploy a demo-image-base image for jetson-xavier-nx-devkit machine:
+  $ $0 --machine jetson-xavier-nx-devkit  --image demo-image-base
+EOF
+}
+
+# get command line options
+SHORTOPTS="hm:i:"
+LONGOPTS="help,machine:,image:"
+
+ARGS=$(getopt --options $SHORTOPTS --longoptions $LONGOPTS --name $PROGNAME -- "$@" )
+if [ $? != 0 ]; then
+   usage
+   exit 1
+fi
+
+eval set -- "$ARGS"
+while true;
+do
+    case $1 in
+        -h | --help)       usage; exit 0 ;;
+        -m | --machine)    MACHINE="$2"; shift 2;;
+        -i | --image)      IMAGE="$2"; shift 2;;
+        -- )               shift; break ;;
+        * )                break ;;
+    esac
+done
+
+if [ -z "$MACHINE" ]; then
+    echo "You must specify a machine"
+    usage
+    exit 1
+fi
+
+if [ -z "$IMAGE" ]; then
+    echo "You must specify an image"
+    usage
+    exit 1
+fi
+
+echo "Using machine ${MACHINE} image ${IMAGE}"
+deployfile=${IMAGE}-${MACHINE}.tegraflash.tar.gz
+scriptdir=$(realpath $(dirname $0))
+tmpdir=`mktemp`
+rm -rf $tmpdir
+mkdir -p $tmpdir
+echo "Using temp directory $tmpdir"
+currentdir=$(realpath .)
+cd $tmpdir
+cp $scriptdir/../../../build/tmp/deploy/images/${MACHINE}/$deployfile .
+tar -xvf $deployfile
+set +e
+./doflash.sh
+rc=$?
+if [ $rc -ne 0 ]; then
+    if [ ! -e /etc/udev/rules.d/??-oe4t.rules ]; then
+        echo "No rules file exists and flash failed."
+        echo "You may need to run setup-udev-rules"
+        echo "Or run this script as root"
+    fi
+fi
+cd $currentdir
+echo "Removing temp directory $tmpdir"
+rm -rf $tmpdir
+exit $rc

--- a/layers/meta-tegrademo/scripts/setup-udev-rules
+++ b/layers/meta-tegrademo/scripts/setup-udev-rules
@@ -1,0 +1,39 @@
+#!/bin/sh
+if [ "$(id -u)" -ne 0 ]; then
+    echo "You may need to run this script as sudo if you see permission errors"
+fi
+if [ ! -z "${SUDO_USER}" ]; then
+    user=${SUDO_USER}
+else
+    user=`whoami`
+fi
+set -e
+cat << EOF > /etc/udev/rules.d/99-oe4t.rules
+# Jetson TK1
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7140", GROUP="plugdev"
+# Jetson TX1
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7721", GROUP="plugdev"
+# Jetson TX2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7c18", GROUP="plugdev"
+# Jetson TX2i
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7018", GROUP="plugdev"
+# Jetson TX2-4GB
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7418", GROUP="plugdev"
+# Jetson AGX Xavier
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7019", GROUP="plugdev"
+# Jetson Xavier NX
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7e19", GROUP="plugdev"
+# Jetson Nano
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7f21", GROUP="plugdev"
+EOF
+udevadm control --reload
+echo "udev settings applied, please disconnect/reconnect your device"
+set +e
+groups ${user} | grep "plugdev" > /dev/null 2>&1
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "Please add ${user} to plugdev using:"
+    echo "sudo usermod -a -G plugdev  ${user}"
+    echo "Then apply to your user by logging back into the session or running"
+    echo "newgrp plugdev"
+fi


### PR DESCRIPTION
Thanks for getting the repo up to date for the mender community upstream @madisongh 

There are two other changes here I was thinking we may want to backport to dunfell r32.4.3 since that's our stable mender branch.  They may make sense in r32.5.0 and/or gatesgarth too.

* I'd like to move the deploy script into the demo distro since I've removed the one I had in meta-mender-community with https://github.com/mendersoftware/meta-mender-community/pull/221
* I think we should make the `cboot-t18x` the default bootloader for the `tegrademo-mender` distro.  It's maybe not typical to put a change like this on a stable branch but since this shouldn't impact anyone's existing custom distribution and is documented clearly in the README I'd hope it would be safe.  Also we've found from experience you can get into confusing situations if you use uboot or cboot-prebuilt, so making one less thing someone needs to get right in their demo setup for those still using `jetson-tx2` could be useful.