### PR TITLE
rootfs-postcommands-overrides: make conditional on read-only-rootfs

### DIFF
--- a/layers/meta-tegrademo/classes/rootfs-postcommands-overrides.bbclass
+++ b/layers/meta-tegrademo/classes/rootfs-postcommands-overrides.bbclass
@@ -32,4 +32,4 @@ replacement_read_only_rootfs_hook() {
 }
 
 ROOTFS_POSTPROCESS_COMMAND_remove_tegrademo-mender = "read_only_rootfs_hook;"
-ROOTFS_POSTPROCESS_COMMAND_append_tegrademo-mender = " replacement_read_only_rootfs_hook;"
+ROOTFS_POSTPROCESS_COMMAND_append_tegrademo-mender = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' replacement_read_only_rootfs_hook;', '', d)}"


### PR DESCRIPTION
While it's typical to use a read-only rootfs with Mender,
we shouldn't assume it, so run the replacement scriptlet
only when IMAGE_FEATURES has read-only-rootfs set.

Signed-off-by: Matt Madison <matt@madison.systems>