### PR TITLE
u-boot-tegra: enable FIT image support with mender and overrides for …

### DIFF
--- a/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo-mender.conf
@@ -42,6 +42,8 @@ IMAGE_INSTALL_append_tegra = " tegra-eeprom-tool i2c-tools tegra-bup-payload"
 TEGRA_FLASH_PARTITIONS_MB_jetson-nano-2gb-devkit = "5046"
 MENDER_DATA_PART_NUMBER_jetson-nano-devkit = "3"
 MENDER_ROOTFS_PART_B_NUMBER_jetson-nano-devkit = "2"
+MENDER_DATA_PART_NUMBER_jetson-nano-devkit-emmc = "19"
+MENDER_ROOTFS_PART_B_NUMBER_jetson-nano-devkit-emmc = "18"
 # Swap is in partition 3 on the 2GB devkit
 MENDER_DATA_PART_NUMBER_jetson-nano-2gb-devkit = "4"
 MENDER_ROOTFS_PART_B_NUMBER_jetson-nano-2gb-devkit = "2"

--- a/layers/meta-tegrademo/recipes-bsp/u-boot/u-boot-tegra/0018-env-enable-fit-image-support-with-mender.patch
+++ b/layers/meta-tegrademo/recipes-bsp/u-boot/u-boot-tegra/0018-env-enable-fit-image-support-with-mender.patch
@@ -1,0 +1,52 @@
+From d69350d6ddfe7b2acd5626b68a8fa8eeea47251d Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Fri, 21 May 2021 14:47:18 +0100
+Subject: [PATCH] env: enable fit image support with mender
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+---
+ include/env_mender.h | 24 +++++++++++++++++++-----
+ 1 file changed, 19 insertions(+), 5 deletions(-)
+
+diff --git a/include/env_mender.h b/include/env_mender.h
+index fbed122807..e02ce3ac57 100644
+--- a/include/env_mender.h
++++ b/include/env_mender.h
+@@ -144,15 +144,29 @@
+     "load ${mender_uboot_root} ${kernel_addr_r} /boot/${mender_kernel_name}; "
+ #endif
+ 
+-#define CONFIG_MENDER_BOOTCOMMAND                                       \
++#define CONFIG_MENDER_BOOTCOMMAND_COMMON                                \
+     "run mender_setup; "                                                \
+-    "setenv distro_bootpart ${mender_boot_part}; "			\
+-    "setenv distro_bootpart_hex ${mender_boot_part_hex}; "		\
+-    "setenv devnum " __stringify(MENDER_UBOOT_STORAGE_DEVICE) "; " 	\
++    "setenv distro_bootpart ${mender_boot_part}; "                      \
++    "setenv distro_bootpart_hex ${mender_boot_part_hex}; "              \
++    "setenv devnum " __stringify(MENDER_UBOOT_STORAGE_DEVICE) "; "      \
+     "setenv devtype " __stringify(MENDER_UBOOT_STORAGE_INTERFACE) "; "  \
+-    "setenv prefix /boot/; " 						\
++    "setenv prefix /boot/; "                                            \
++
++#ifndef CONFIG_FIT
++#define CONFIG_MENDER_BOOTCOMMAND                                       \
++    CONFIG_MENDER_BOOTCOMMAND_COMMON                                    \
+     "sysboot ${devtype} ${devnum}:${distro_bootpart_hex} any ${scriptaddr} ${prefix}extlinux/extlinux.conf; " \
+     "run mender_try_to_recover"
++#else
++#define CONFIG_MENDER_BOOTCOMMAND                                       \
++    CONFIG_MENDER_BOOTCOMMAND_COMMON                                    \
++    MENDER_BOOTARGS                                                     \
++    "setenv bootargs ${bootargs} ${cbootargs} ro rootwait; "            \
++    "setenv load_fitimage load ${devtype} ${devnum}:${distro_bootpart_hex} ${fit_addr} ${prefix}${mmcfit_name}; " \
++    "run load_fitimage; "                                               \
++    "bootm ${fit_addr} - ${fdt_addr}; "                                 \
++    "run mender_try_to_recover"
++#endif /* CONFIG_FIT */
+ 
+ #endif /* !MENDER_AUTO_PROBING */
+ 
+-- 
+2.17.1
+

--- a/layers/meta-tegrademo/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-tegrademo/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append_cot = " \
   file://enable-fitimage-support.cfg \
   ${@'file://enable-fitimage-signing.cfg' if d.getVar('UBOOT_SIGN_ENABLE') == '1' else ''} \
 "
+SRC_URI_append_cot_mender-uboot = " file://0018-env-enable-fit-image-support-with-mender.patch"
 
 RDEPENDS_${PN}_remove_cot = "${PN}-extlinux"
 


### PR DESCRIPTION
…Nano (eMMC version)

    partition numbers in distro conf file.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>