### PR TITLE
Add https protocol to SRC_URI of eglstreams-kms-example

### DIFF
--- a/layers/meta-tegra-support/recipes-test/eglstreams/eglstreams-kms-example_git.bb
+++ b/layers/meta-tegra-support/recipes-test/eglstreams/eglstreams-kms-example_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "libdrm virtual/egl"
 
 SRC_REPO ?= "github.com/madisongh/eglstreams-kms-example"
 SRCBRANCH ?= "master"
-SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH}"
+SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH};protocol=https"
 SRCREV = "${AUTOREV}"
 PV = "1.0+git${SRCPV}"
 


### PR DESCRIPTION
Most other recipes use https and it is needed for downloading through company firewall.