### PR TITLE
backport VPI tests from master to dunfell-l4t-r32.5.0 branch

### DIFF
--- a/layers/meta-tegra-support/recipes-test/tegra-tests/vpi1-tests/run-vpi1-tests.sh
+++ b/layers/meta-tegra-support/recipes-test/tegra-tests/vpi1-tests/run-vpi1-tests.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021, OpenEmbedded for Tegra Project
+#
+# WARNING: make sure you have at least a couple of GiB of free
+# space availabe in the current working directory, as some of
+# these samples generate very large files.
+#
+# Some of these tests work better if you use jetson_clocks to
+# speed things up.
+
+TEGRACHIPID="$(printf "0x%02x" $(cat /sys/module/tegra_fuse/parameters/tegra_chip_id))"
+SAMPLEROOT="/opt/nvidia/vpi1"
+PATH="$SAMPLEROOT/bin:$PATH"
+SAMPLEASSETS="$SAMPLEROOT/assets"
+SKIPCODE=97
+
+run_convolve_2d() {
+    if [ "$TEGRACHIPID" != "0x19" ] && [ "$1" = "pva" ]; then
+        echo "Skipping 01_convolve_2d - pva backend is not supported"
+        return $SKIPCODE
+    fi
+    echo "Running 01_convolve_2d - Backend is $1"
+    vpi_sample_01_convolve_2d "$1" "$SAMPLEASSETS/kodim08.png"
+}
+
+run_stereo_disparity() {
+    if [ "$TEGRACHIPID" != "0x19" ] && [ "$1" = "pva" ]; then
+        echo "Skipping 02_stereo_disparity - pva backend is not supported"
+        return $SKIPCODE
+    fi
+    echo "Running 02_stereo_disparity - Backend is $1"
+    vpi_sample_02_stereo_disparity "$1" "$SAMPLEASSETS/chair_stereo_left.png" "$SAMPLEASSETS/chair_stereo_right.png"  
+}
+
+run_harris_corners() {
+    if [ "$TEGRACHIPID" != "0x19" ] && [ "$1" = "pva" ]; then
+        echo "Skipping 03_harris_corners - pva backend is not supported"
+        return $SKIPCODE
+    fi
+    echo "Running 03_harris_corners - Backend is $1"
+    vpi_sample_03_harris_corners "$1" "$SAMPLEASSETS/kodim08.png"
+}
+
+run_rescale() {
+    if [ "$TEGRACHIPID" != "0x19" ] && [ "$1" = "pva" ]; then
+        echo "Skipping 04_rescale - pva backend is not supported"
+        return $SKIPCODE
+    fi
+    echo "Running 04_rescale - Backend is $1"
+    vpi_sample_04_rescale "$1" "$SAMPLEASSETS/kodim08.png"
+}
+
+run_timing() {
+    if [ "$TEGRACHIPID" != "0x19" ] && [ "$1" = "pva" ]; then
+        echo "Skipping 05_timing - pva backend is not supported"
+        return $SKIPCODE
+    fi
+    echo "Running 05_timing - Backend is $1"
+    vpi_sample_05_timing "$1"
+}
+
+run_klt_tracker() {
+    if [ ! -x "$SAMPLEROOT/bin/vpi_sample_06_klt_tracker" ]; then
+        echo "Skipping 06_klt_tracker"
+        return $SKIPCODE
+    fi
+    if [ "$TEGRACHIPID" != "0x19" ] && [ "$1" = "pva" ]; then
+        echo "Skipping 06_klt_tracker - pva backend is not supported"
+        return $SKIPCODE
+    fi
+    echo "Running 06_klt_tracker - Backend is $1"
+    vpi_sample_06_klt_tracker "$1" "$SAMPLEASSETS/dashcam.mp4" "$SAMPLEASSETS/dashcam_bboxes.txt" "klt_$1.mp4"
+}
+
+run_fft() {
+    echo "Running 07_fft - Backend is $1"
+    vpi_sample_07_fft "$1" "$SAMPLEASSETS/kodim08.png"
+ 
+}
+
+run_tnr() {
+    if [ ! -x "$SAMPLEROOT/bin/vpi_sample_09_tnr" ]; then
+        echo "Skipping 09_tnr"
+        return $SKIPCODE
+    fi
+    echo "Running 09_tnr - Backend is $1"
+    vpi_sample_09_tnr "$1" "$SAMPLEASSETS/noisy.mp4" "denoised_$1.mp4"
+}
+
+run_perspwarp() {
+    if [ ! -x "$SAMPLEROOT/bin/vpi_sample_10_perspwarp" ]; then
+        echo "Skipping 10_perspwarp"
+        return $SKIPCODE
+    fi
+    echo "Running 10_perspwarp - Backend is $1"
+    vpi_sample_10_perspwarp "$1" "$SAMPLEASSETS/noisy.mp4" "perspwarp_$1.mp4"
+}
+
+run_fisheye() {
+    echo "Running 11_fisheye"
+    vpi_sample_11_fisheye -c 10,7 -s 22 "$SAMPLEASSETS/fisheye/"*.jpg
+}
+
+run_optflow_lk() {
+    if [ ! -x "$SAMPLEROOT/bin/vpi_sample_12_optflow_lk" ]; then
+        echo "Skipping 12_optflow_lk"
+        return $SKIPCODE
+    fi
+    echo "Running 12_optflow_lk - Backend is $1"
+    vpi_sample_12_optflow_lk "$1" "$SAMPLEASSETS/dashcam.mp4" 5 frame.png
+}
+
+# VPI samples list
+TESTS="convolve_2d stereo_disparity harris_corners rescale timing"
+TESTS="$TESTS klt_tracker fft tnr perspwarp fisheye optflow_lk "
+
+# List of VPI backend per sample app
+convolve_2d=("cpu" "cuda" "pva")
+stereo_disparity=("cpu" "cuda" "pva")
+harris_corners=("cpu" "cuda" "pva")
+rescale=("cpu" "cuda" "vic")
+timing=("cpu" "cuda" "pva")
+klt_tracker=("cpu" "cuda" "pva")
+fft=("cpu" "cuda")
+tnr=("cuda" "vic")
+perspwarp=("cpu" "cuda")
+fisheye=("cuda")
+optflow_lk=("cpu" "cuda")
+
+find_test() {
+    for t in $TESTS; do
+    if [ "$t" = "$1" ]; then
+        echo "$t"
+        return
+    fi
+    done
+}
+
+jetson_clocks
+
+testcount=0
+testpass=0
+testfail=0
+if [ $# -eq 0 ]; then
+    tests_to_run="$TESTS"
+else
+    tests_to_run="$@"
+fi
+
+for cand in $tests_to_run; do
+    t=$(find_test "$cand")
+    if [ -z "$t" ]; then
+        echo "ERR: unknown test: $cand" >&2
+    else
+        declare -n backendList=$t
+        for backend in ${backendList[@]}; do
+            testcount=$((testcount+1))
+            echo "=== BEGIN: $t ==="
+            if run_$t $backend; then
+                echo "=== PASS:  $t ==="
+                testpass=$((testpass+1))
+            elif [ $? -eq $SKIPCODE ]; then
+                echo "=== SKIP:  $t ==="
+                testskip=$((testskip+1))
+                break
+            else
+                echo "=== FAIL:  $t ==="
+                testfail=$((testfail+1))
+            fi
+        done
+    fi
+done
+
+echo "Tests run:     $testcount"
+echo "Tests passed:  $testpass"
+echo "Tests skipped: $testskip"
+echo "Tests failed:  $testfail"
+exit $testfail

--- a/layers/meta-tegra-support/recipes-test/tegra-tests/vpi1-tests_1.0.bb
+++ b/layers/meta-tegra-support/recipes-test/tegra-tests/vpi1-tests_1.0.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Scripts for testing Tegra VPI samples"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+SRC_URI = "\
+    file://run-vpi1-tests.sh \
+"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+S = "${WORKDIR}"
+
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/run-vpi1-tests.sh ${D}${bindir}/run-vpi1-tests
+}
+
+PACKAGE_ARCH = "${TEGRA_PKGARCH}"
+RDEPENDS:${PN} = "vpi1-samples tegra-tools-jetson-clocks"

--- a/layers/meta-tegra-support/recipes-test/tegra-tests/vpi1-tests_1.0.bb
+++ b/layers/meta-tegra-support/recipes-test/tegra-tests/vpi1-tests_1.0.bb
@@ -17,4 +17,4 @@ do_install() {
 }
 
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
-RDEPENDS:${PN} = "vpi1-samples tegra-tools-jetson-clocks"
+RDEPENDS_${PN} = "vpi1-samples tegra-tools-jetson-clocks"

--- a/layers/meta-tegrademo/conf/template-tegrademo-mender/conf-notes.txt
+++ b/layers/meta-tegrademo/conf/template-tegrademo-mender/conf-notes.txt
@@ -7,4 +7,4 @@ Targets for building Tegra demo images with test applications:
     demo-image-egl      - basic image with DRM/EGL, no window manager
     demo-image-sato     - X11 image with 'sato' UI
     demo-image-weston   - Wayland with Weston compositor
-    demo-image-full     - X11/sato UI plus docker, openCV, multimedia API samples
+    demo-image-full     - X11/sato UI plus docker, openCV, VPI samples, multimedia API samples

--- a/layers/meta-tegrademo/conf/template-tegrademo/conf-notes.txt
+++ b/layers/meta-tegrademo/conf/template-tegrademo/conf-notes.txt
@@ -7,4 +7,4 @@ Targets for building Tegra demo images with test applications:
     demo-image-egl      - basic image with DRM/EGL, no window manager
     demo-image-sato     - X11 image with 'sato' UI
     demo-image-weston   - Wayland with Weston compositor
-    demo-image-full     - X11/sato UI plus docker, openCV, multimedia API samples
+    demo-image-full     - X11/sato UI plus docker, openCV, VPI samples, multimedia API samples

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-full.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-full.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Full Tegra demo image with X11/Sato, nvidia-docker, OpenCV, \
-and Tegra multimedia API sample apps."
+VPI samples, and Tegra multimedia API sample apps."
 
 require demo-image-common.inc
 
@@ -11,4 +11,4 @@ REQUIRED_DISTRO_FEATURES = "x11 opengl virtualization"
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-x11tests"
 CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'packagegroup-demo-vulkantests', '', d)}"
-CORE_IMAGE_BASE_INSTALL += "libvisionworks-devso-symlink nvidia-docker cuda-libraries tegra-mmapi-samples"
+CORE_IMAGE_BASE_INSTALL += "libvisionworks-devso-symlink nvidia-docker cuda-libraries tegra-mmapi-samples vpi1-tests"


### PR DESCRIPTION
* tests were done by using `Jetson TX2` 

```
root@jetson-tx2-devkit:~# run-vpi1-tests 
=== BEGIN: convolve_2d ===
...
Tests run:     27
Tests passed:  20
Tests skipped: 5
Tests failed:  2
root@jetson-tx2-devkit:~# 
```