### PR TITLE
westontests: only build gstreamer-tests if x11 is in DISTRO_FEATURES

### DIFF
--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-westontests.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-westontests.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
-    gstreamer-tests \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gstreamer-tests', '', d)} \
     l4t-graphics-demos-wayland \
     weston-examples \
 "


### PR DESCRIPTION
gstreamer-tests needs x11 for nvvideosinks. Don't build it without x11 in DISTRO_FEATURES.