### PR TITLE
meta-tegrademo: add tegrademo-devicetree recipes

### DIFF
--- a/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree/tegra194-p2888-0001-p2822-0000-oe4t.dts
+++ b/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree/tegra194-p2888-0001-p2822-0000-oe4t.dts
@@ -1,0 +1,9 @@
+#include "tegra194-p2888-0001-p2822-0000.dts"
+
+/* adds compatible string for oe4t, for demonstration purposes */
+/ {
+	nvidia,dtsfilename = __FILE__;
+	nvidia,dtbbuildtime = __DATE__, __TIME__;
+
+	compatible = "oe4t,p2822-0000+p2888-0001+tegrademo", "nvidia,galen", "nvidia,jetson-xavier", "nvidia,p2822-0000+p2888-0001", "nvidia,tegra194";
+};

--- a/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree/tegra194-p3668-all-p3509-0000-oe4t.dts
+++ b/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree/tegra194-p3668-all-p3509-0000-oe4t.dts
@@ -1,0 +1,9 @@
+#include "tegra194-p3668-all-p3509-0000.dts"
+
+/* adds compatible string for oe4t, for demonstration purposes */
+/ {
+	nvidia,dtsfilename = __FILE__;
+	nvidia,dtbbuildtime = __DATE__, __TIME__;
+
+	compatible = "oe4t,p3449-0000+p3668-0000+tegrademo", "nvidia,p3449-0000+p3668-0000", "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0000", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
+};

--- a/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree_1.0.bb
+++ b/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree_1.0.bb
@@ -1,0 +1,43 @@
+DESCRIPTION = "Meta-tegrademo example device trees for out-of-tree builds."
+HOMEPAGE = "https://github.com/OE4T"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit devicetree
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+SRC_URI = "\
+    file://tegra194-p2888-0001-p2822-0000-oe4t.dts \
+    file://tegra194-p3668-all-p3509-0000-oe4t.dts \
+"
+
+KERNEL_INCLUDE = " \
+    ${STAGING_KERNEL_DIR}/nvidia/soc/tegra/kernel-include \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/tegra/common/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/soc/t19x/kernel-include \
+    ${STAGING_KERNEL_DIR}/nvidia/soc/t19x/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/t19x/common/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/soc/t23x/kernel-include \
+    ${STAGING_KERNEL_DIR}/nvidia/soc/t23x/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/t23x/common/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/t19x/galen/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/t19x/jakku/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/t19x/mccoy/kernel-dts \
+    ${STAGING_KERNEL_DIR}/nvidia/platform/t23x/concord/kernel-dts \
+    ${STAGING_KERNEL_DIR}/scripts/dtc/include-prefixes \
+"
+
+# Straight from arch/arm64/boot/dts in kernel source tree
+DTC_PPFLAGS:append = " -DLINUX_VERSION=504 -DTEGRA_HOST1X_DT_VERSION=1"
+
+# re-implement function from devicetree.bbclass to preserve order of KERNEL_INCLUDE
+def expand_includes(varname, d):
+    import glob
+    includes = list()
+    # expand all includes with glob
+    for i in (d.getVar(varname) or "").split():
+        for g in glob.glob(i):
+            if os.path.isdir(g): # only add directories to include path
+                includes.append(g)
+    return includes


### PR DESCRIPTION
This recipe adds a couple example devicetree files to demonstrate the use of the virtual/dtb provider. To use these device trees in a build, something like the following can be added to the local.conf:

```
PREFERRED_PROVIDER_virtual/dtb = "tegrademo-devicetree"
DTBFILE:jetson-xavier-nx-devkit = "tegra194-p3668-all-p3509-0000-oe4t.dtb"
DTBFILE:jetson-xavier-nx-devkit-emmc = "tegra194-p3668-all-p3509-0000-oe4t.dtb"
DTBFILE:jetson-agx-xavier-devkit = "tegra194-p2888-0001-p2822-0000-oe4t.dtb"
```

---

Note that in order to build this, the changes from https://github.com/OE4T/linux-tegra-5.10/pull/3 are required, at least as far as I could tell. If there is a better way to handle this, please let me know.