### PR TITLE
scripts: Fix create-distro-layer mender option

### DIFF
--- a/scripts-setup/create-distro-layer
+++ b/scripts-setup/create-distro-layer
@@ -75,9 +75,15 @@ if [ -d layers/meta-tegrademo ]; then
     rm -rf ${LAYER_DIR}/conf/template-tegrademo-mender
 
     # Adjust the data in conf/distro
-    cat ${LAYER_DIR}/conf/distro/tegrademo.conf > ${LAYER_DIR}/conf/distro/${DISTRO_NAME}.conf
+    cp ${LAYER_DIR}/conf/distro/tegrademo.conf ${LAYER_DIR}/conf/distro/${DISTRO_NAME}.conf
     if [ "${MENDER}" = true ]; then
-        cat ${LAYER_DIR}/conf/distro/tegrademo-mender.conf | tail -n +6 >> ${LAYER_DIR}/conf/distro/${DISTRO_NAME}.conf
+        cp ${LAYER_DIR}/conf/distro/tegrademo-mender.conf ${LAYER_DIR}/conf/distro/${DISTRO_NAME}.conf
+        # The mender layer needs to require the tegrademo.conf file and then replace the "include"
+        # line at the top to reference this file.  However, we can't let the global find/replace below
+        # remove the include.  So rename this file ${DISTRO_NAME} base and replace the reference here
+        # before the global find/replace below.
+        cp ${LAYER_DIR}/conf/distro/tegrademo.conf ${LAYER_DIR}/conf/distro/${DISTRO_NAME}-base.conf
+        sed -i "s/tegrademo.conf/${DISTRO_NAME}-base.conf/" ${LAYER_DIR}/conf/distro/${DISTRO_NAME}.conf
     fi
     rm -rf ${LAYER_DIR}/conf/distro/tegrademo.conf
     rm -rf ${LAYER_DIR}/conf/distro/tegrademo-mender.conf


### PR DESCRIPTION
The previous implementation assumed `REQUIRED_TD_BBLAYERS_CONF_VERSION` was the same between the base distro and the mender distro script.

Instead of attempting to patch the distro.conf file with tegrademo-mender content, use the tegrademo-mender content as-is.

Then tweak the copy scripts in the mender case to avoid replacing the tegrademo.conf reference in the distro configuration copied from the mender config.  Use the name `${DISTRO_NAME}-base.conf` for the file created from `tegrademo.conf` to avoid
name collisions with the later rename scripts.

Tested with
```
./scripts-setup/create-distro-layer -d my-mender -m
. ./setup-env -m jetson-nano-devkit-emmc -d my-mender build-my-mender
```
and
```
./scripts-setup/create-distro-layer -d my-distro
. ./setup-env -m jetson-nano-devkit-emmc -d my-distro build-my-distro
```




Closes https://github.com/OE4T/tegra-demo-distro/issues/232

Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>