### PR TITLE
Fix s3retry_wait typo

### DIFF
--- a/layers/meta-demo-ci/lib/oeaws/s3session.py
+++ b/layers/meta-demo-ci/lib/oeaws/s3session.py
@@ -52,7 +52,7 @@ class S3Session(object):
             try:
                 self.s3client.upload_file(Bucket=Bucket, Key=Key, Filename=Filename)
             except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError):
-                s3tretry_wait(attempt)
+                s3retry_wait(attempt)
                 continue
             except botocore.exceptions.ClientError as e:
                 err = e.repsonse['Error']


### PR DESCRIPTION
Corrects a typo found when sso credentials expired before uploads occurred.