### PR TITLE
feat: tegrademo.conf: move setup-independent parts into include

### DIFF
--- a/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
+++ b/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
@@ -1,0 +1,57 @@
+DISTRO = "tegrademo"
+DISTRO_NAME = "OE4Tegra Demonstration Distro"
+DISTRO_VERSION_BASE = "4.2"
+DISTRO_VERSION = "${DISTRO_VERSION_BASE}+snapshot-${METADATA_REVISION}"
+DISTRO_CODENAME = "master"
+SDK_VENDOR = "-tdsdk"
+SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${METADATA_REVISION}','snapshot')}"
+SDK_VERSION[vardepvalue] = "${SDK_VERSION}"
+
+MAINTAINER = "OE4Tegra team <oe4tegra@madison.systems>"
+
+TARGET_VENDOR = "-oe4t"
+
+# New ${DISTRO}-<version> setting for sanity checks.
+# Increment version number (and the corresponding
+# setting int the template bblayers.conf.sample file)
+# each time the layer settings are changed.
+REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-5"
+
+LOCALCONF_VERSION = "2"
+
+TD_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan systemd pam virtualization"
+
+DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${TD_DEFAULT_DISTRO_FEATURES}"
+
+# Jetson platforms do not use linux-yocto, but for QEMU testing
+# align with the poky distro.
+PREFERRED_VERSION_linux-yocto ?= "5.19%"
+PREFERRED_VERSION_linux-yocto-rt ?= "5.19%"
+
+SDK_NAME = "${DISTRO}-${TCLIBC}-${SDKMACHINE}-${IMAGE_BASENAME}-${TUNE_PKGARCH}-${MACHINE}"
+SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}"
+
+TCLIBCAPPEND = ""
+
+PACKAGE_CLASSES ?= "package_rpm"
+
+SANITY_TESTED_DISTROS ?= " \
+            ubuntu-18.04 \n \
+            ubuntu-20.04 \n \
+            ubuntu-22.04 \n \
+            "
+
+# CUDA 10.2 requires gcc 8
+CUDA_GCCVERSION = "8.%"
+
+# Most NVIDIA-supplied services expect systemd
+INIT_MANAGER = "systemd"
+
+require conf/distro/include/no-static-libs.inc
+require conf/distro/include/yocto-uninative.inc
+require conf/distro/include/security_flags.inc
+INHERIT += "uninative"
+
+LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264"
+
+OLDEST_KERNEL:aarch64 = "5.10"

--- a/layers/meta-tegrademo/conf/distro/tegrademo.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo.conf
@@ -1,63 +1,7 @@
-DISTRO = "tegrademo"
-DISTRO_NAME = "OE4Tegra Demonstration Distro"
-DISTRO_VERSION_BASE = "4.2"
-DISTRO_VERSION = "${DISTRO_VERSION_BASE}+snapshot-${METADATA_REVISION}"
-DISTRO_CODENAME = "master"
-SDK_VENDOR = "-tdsdk"
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${METADATA_REVISION}','snapshot')}"
-SDK_VERSION[vardepvalue] = "${SDK_VERSION}"
-
-MAINTAINER = "OE4Tegra team <oe4tegra@madison.systems>"
-
-TARGET_VENDOR = "-oe4t"
-
-# New ${DISTRO}-<version> setting for sanity checks.
-# Increment version number (and the corresponding
-# setting int the template bblayers.conf.sample file)
-# each time the layer settings are changed.
-REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-5"
-
-LOCALCONF_VERSION = "2"
-
-TD_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan systemd pam virtualization"
-
-DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${TD_DEFAULT_DISTRO_FEATURES}"
-
-# Jetson platforms do not use linux-yocto, but for QEMU testing
-# align with the poky distro.
-PREFERRED_VERSION_linux-yocto ?= "5.19%"
-PREFERRED_VERSION_linux-yocto-rt ?= "5.19%"
-
-SDK_NAME = "${DISTRO}-${TCLIBC}-${SDKMACHINE}-${IMAGE_BASENAME}-${TUNE_PKGARCH}-${MACHINE}"
-SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}"
-
-TCLIBCAPPEND = ""
-
-PACKAGE_CLASSES ?= "package_rpm"
-
-SANITY_TESTED_DISTROS ?= " \
-            ubuntu-18.04 \n \
-            ubuntu-20.04 \n \
-            ubuntu-22.04 \n \
-            "
-
-# CUDA 10.2 requires gcc 8
-CUDA_GCCVERSION = "8.%"
-
-# Most NVIDIA-supplied services expect systemd
-INIT_MANAGER = "systemd"
+require conf/distro/include/tegrademo.inc
 
 INHERIT += "tegra-support-sanity"
 ESDK_CLASS_INHERIT_DISABLE:append = " tegra-support-sanity"
 
-require conf/distro/include/no-static-libs.inc
-require conf/distro/include/yocto-uninative.inc
-require conf/distro/include/security_flags.inc
-INHERIT += "uninative"
-
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
-
-LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264"
-
-OLDEST_KERNEL:aarch64 = "5.10"


### PR DESCRIPTION
The current state of the tegrademo.conf distribution configuration file takes a couple of assumptions on the environment it will be used in. The primary one is using the setup-env.sh script from the tegra-demo-distro repository,  which means bblayers.conf has to be set up. This breaks other build flows and makes it hard for other distribution configurations to derive from tegrademo. By moving the setup agnostic parts (e.g. the ones defining the ABI/API) into an include file, they can be easily used as a base for customized distributions.

Changelog: Title
Ticket: None