### PR TITLE
mirror_update.bbclass: add fix environment function to get AWS credentials

### DIFF
--- a/layers/meta-demo-ci/classes/mirror_updates.bbclass
+++ b/layers/meta-demo-ci/classes/mirror_updates.bbclass
@@ -22,6 +22,11 @@ SSTATE_MIRROR_URL ??= ""
 
 python downloads_mirror_update() {
     import os, shutil, urllib.parse
+    try:
+        from oeaws import aws_env
+        aws_env.fix_env(d)
+    except ImportError:
+        pass
 
     src_uri = (d.getVar("SRC_URI") or "").split()
     if len(src_uri) == 0:
@@ -79,6 +84,11 @@ python downloads_mirror_update() {
 
 python sstate_mirror_update() {
     import os, shutil, urllib.parse
+    try:
+        from oeaws import aws_env
+        aws_env.fix_env(d)
+    except ImportError:
+        pass
 
     if d.getVar('SSTATE_SKIP_CREATION') == '1':
         return
@@ -117,7 +127,7 @@ python () {
     try:
         from oeaws import s3session
     except ImportError:
-        s3session = None
+        pass
 
     if bb.utils.to_boolean(d.getVar("UPDATE_DOWNLOADS_MIRROR")):
         mirror = urllib.parse.urlparse(d.getVar("DOWNLOADS_MIRROR_URL"))

--- a/layers/meta-demo-ci/lib/oeaws/aws_env.py
+++ b/layers/meta-demo-ci/lib/oeaws/aws_env.py
@@ -1,0 +1,34 @@
+# ex:ts=4:sw=4:sts=4:et
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
+"""
+Fix AWS env for S3 fetcher
+Extracted from botos3fetcher in order to be used in bbclass too
+
+Copyright (c) 2019-2020, Matthew Madison <matt@madison.systems>
+"""
+import os
+
+import bb
+
+awsvars = [ 'AWS_CONFIG_FILE',
+            'AWS_PROFILE',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_SHARED_CREDENTIALS_FILE',
+            'AWS_SESSION_TOKEN',
+            'AWS_DEFAULT_REGION',
+            'AWS_METADATA_SERVICE_NUM_ATTEMPTS',
+            'AWS_METADATA_SERVICE_TIMEOUT']
+
+def fix_env(d):
+    origenv = d.getVar('BB_ORIGENV', False)
+    for v in awsvars:
+        val = os.getenv(v)
+        if val:
+            bb.debug(2, "Have %s=%s in env" % (v, val))
+            continue
+        val = origenv and origenv.getVar(v)
+        if val:
+            os.environ[v] = val
+            bb.debug(2, 'Set %s=%s in env' % (v, val))
+        bb.debug(2, 'No setting for %s' % v)

--- a/layers/meta-demo-ci/lib/oeaws/botos3fetcher.py
+++ b/layers/meta-demo-ci/lib/oeaws/botos3fetcher.py
@@ -13,18 +13,9 @@ dependencies, installed prior to use.
 Copyright (c) 2019-2020, Matthew Madison <matt@madison.systems>
 """
 
-import os
+import aws_env
 import bb
 
-awsvars = [ 'AWS_CONFIG_FILE',
-            'AWS_PROFILE',
-            'AWS_ACCESS_KEY_ID',
-            'AWS_SECRET_ACCESS_KEY',
-            'AWS_SHARED_CREDENTIALS_FILE',
-            'AWS_SESSION_TOKEN',
-            'AWS_DEFAULT_REGION',
-            'AWS_METADATA_SERVICE_NUM_ATTEMPTS',
-            'AWS_METADATA_SERVICE_TIMEOUT']
 
 class S3(bb.fetch2.s3.S3):
 
@@ -32,25 +23,12 @@ class S3(bb.fetch2.s3.S3):
         super().__init__(urls)
         self.session = oeaws.s3session.S3Session()
 
-    def fix_env(self, d):
-        origenv = d.getVar('BB_ORIGENV', False)
-        for v in awsvars:
-            val = os.getenv(v)
-            if val:
-                bb.debug(2, "Have %s=%s in env" % (v, val))
-                continue
-            val = origenv and origenv.getVar(v)
-            if val:
-                os.environ[v] = val
-                bb.debug(2, 'Set %s=%s in env' % (v, val))
-            bb.debug(2, 'No setting for %s' % v)
-
     def checkstatus(self, fetch, ud, d):
-        self.fix_env(d)
+        aws_env.fix_env(d)
         return self.session.get_object_info(ud.host, ud.path[1:]) is not None
 
     def download(self, ud, d):
-        self.fix_env(d)
+        aws_env.fix_env(d)
         if not self.session.download(ud.host, ud.path[1:], ud.localpath):
             raise bb.fetch2.FetchError("could not download s3://%s%s" % (ud.host, ud.path))
         return True


### PR DESCRIPTION
AWS credentials can be provided in environment variables in order for s3Session to access a private bucket.
When credentials are set as environment variables and passed with `BB_ENV_EXTRAWHITE` (or `BB_ENV_PASSTHROUGH_ADDITIONS`) they are not taken into account and do not appear in environment when  `downloads_mirror_update` or `sstate_mirror_update` are called.

This commit move the `fix_env` function from `botos3fetcher.py` into a dedicated file in order to be used in both `botos3fetcher.py` and `mirror_updates.bbclass`