### PR TITLE
setup-env-internal: replace egrep as it is obsolescent

### DIFF
--- a/scripts-setup/setup-env-internal
+++ b/scripts-setup/setup-env-internal
@@ -113,7 +113,7 @@ if [ ! -e $BUILDDIR/conf/local.conf ]; then
     if [ -z "$DISTRO" ]; then
         DISTRO=$DISTRO_DEFAULT
     fi
-    if ! distro_list | egrep -qx "[[:space:]]*$DISTRO"; then
+    if ! distro_list | grep -Eqx "[[:space:]]*$DISTRO"; then
 	echo "ERROR: distro \"$DISTRO\" not found" >&2
 	echo "Available DISTROs:" >&2
 	distro_list >&2
@@ -135,7 +135,7 @@ else
 fi
 
 [ "$NVIDIA_DEVNET_MIRROR" != "" ] || NVIDIA_DEVNET_MIRROR="$HOME/Downloads/nvidia/sdkm_downloads"
-if echo "$NVIDIA_DEVNET_MIRROR" | egrep -q "^[^:]+://"; then
+if echo "$NVIDIA_DEVNET_MIRROR" | grep -Eq "^[^:]+://"; then
     TD_DEVNET_MIRROR="$NVIDIA_DEVNET_MIRROR"
     if [ "${NVIDIA_DEVNET_MIRROR:0:7}" = "file://" ]; then
 	if [ ! -d "${NVIDIA_DEVNET_MIRROR:7}" ]; then


### PR DESCRIPTION
Fixes the following warning:
```
egrep: warning: egrep is obsolescent; using grep -E
```
