### PR TITLE
tegrademo: Update to use A/B Rootfs by default

### DIFF
--- a/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
+++ b/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
@@ -55,3 +55,5 @@ INHERIT += "uninative"
 LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264"
 
 OLDEST_KERNEL:aarch64 = "5.10"
+
+USE_REDUNDANT_FLASH_LAYOUT_DEFAULT ?= "1"


### PR DESCRIPTION
* Update meta-tegra repo to latest supporting [1].
* Set distro configuration to default to A/B redundant rootfs.

1: https://github.com/OE4T/meta-tegra/pull/1428