### PR TITLE
swupdate fixes for master

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -23,13 +23,9 @@ ROOTFS_FILENAME ?= "${SWUPDATE_CORE_IMAGE_NAME}-${MACHINE}.rootfs.tar.gz"
 
 # Handle differences in redundant partition naming on t194 platforms
 KERNEL_A_PARTNAME = "A_kernel"
-KERNEL_A_PARTNAME:tegra194 = "kernel"
 KERNEL_A_DTB_PARTNAME = "A_kernel-dtb"
-KERNEL_A_DTB_PARTNAME:tegra194 = "kernel-dtb"
 KERNEL_B_PARTNAME = "B_kernel"
-KERNEL_B_PARTNAME:tegra194 = "kernel_b"
 KERNEL_B_DTB_PARTNAME = "B_kernel-dtb"
-KERNEL_B_DTB_PARTNAME:tegra194 = "kernel-dtb_b"
 
 # images to build before building swupdate image
 IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -35,4 +35,7 @@ KERNEL_B_DTB_PARTNAME:tegra194 = "kernel-dtb_b"
 IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules"
 
 # images and files that will be included in the .swu image
-SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE}"
+DTBFILE_PATH = "${@'${EXTERNAL_KERNEL_DEVICETREE}/${DTBFILE}' if len(d.getVar('EXTERNAL_KERNEL_DEVICETREE')) else '${DTBFILE}'}"
+SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH}"
+
+do_swuimage[depends] += "${DTB_EXTRA_DEPS}"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
@@ -40,7 +40,7 @@ software =
 				files: (
 					{
 						filename = "tegra-bl.cap";
-						path = "/opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap";
+						path = "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap";
 						properties = {create-destination = "true";}
 					}
 				);
@@ -87,7 +87,7 @@ software =
 				files: (
 					{
 						filename = "tegra-bl.cap";
-						path = "/opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap";
+						path = "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap";
 						properties = {create-destination = "true";}
 					}
 				);


### PR DESCRIPTION
* Fix dependencies for dtbfile reference
* Update the path to the capsule file to match JP6
* Remove overrides no longer used on jp6 branches.

These commits should be ready for backport to `scarthgap` as well.

The first two commits can also go to `scarthgap-l4t-r35.x` (keep the overrides for t194 there)

FYI the master build is broken until https://groups.google.com/g/swupdate/c/U-GNI3mhbX0 or something similar is merged in meta-swupdate.  I've tested locally with these changes on `jetson-orin-nano-devkit-nvme` in these scenarios:

1) master branch to master branch (Jetpack 6)
2) kirkstone branch to master branch (Jetpack 5->6).