### PR TITLE
swupdate: scarthgap fixes

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -35,4 +35,7 @@ KERNEL_B_DTB_PARTNAME:tegra194 = "kernel-dtb_b"
 IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules"
 
 # images and files that will be included in the .swu image
-SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE}"
+DTBFILE_PATH = "${@'${EXTERNAL_KERNEL_DEVICETREE}/${DTBFILE}' if len(d.getVar('EXTERNAL_KERNEL_DEVICETREE')) else '${DTBFILE}'}"
+SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH}"
+
+do_swuimage[depends] += "${DTB_EXTRA_DEPS}"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
@@ -40,7 +40,7 @@ software =
 				files: (
 					{
 						filename = "tegra-bl.cap";
-						path = "/opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap";
+						path = "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap";
 						properties = {create-destination = "true";}
 					}
 				);
@@ -87,7 +87,7 @@ software =
 				files: (
 					{
 						filename = "tegra-bl.cap";
-						path = "/opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap";
+						path = "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap";
 						properties = {create-destination = "true";}
 					}
 				);


### PR DESCRIPTION
Backport of https://github.com/OE4T/tegra-demo-distro/pull/305 to scarthgap, in an attempt to resolve https://github.com/OE4T/tegra-demo-distro/issues/303

I left out https://github.com/OE4T/tegra-demo-distro/pull/305/commits/cf54e8924fdc6de733e9a28af9af20834d998990 and kept tegra194 references for the time being since based on discussion in last month's meeting it may be possible for tegra194 to ultimately be supported on Jetpack 6 through the community layer.