### PR TITLE
swupdate: add kas configurations

### DIFF
--- a/layers/meta-tegrademo/conf/kas/include/tegra-demo-distro-branch.yml
+++ b/layers/meta-tegrademo/conf/kas/include/tegra-demo-distro-branch.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+
+defaults:
+  repos:
+    branch: master

--- a/layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml
+++ b/layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml
@@ -1,0 +1,58 @@
+header:
+  version: 14
+  includes:
+    - repo: meta-tegrademo
+      file: conf/kas/include/tegra-demo-distro-branch.yml
+
+distro: tegrademo
+
+target:
+  - demo-image-base
+
+machine: jetson-orin-nano-devkit
+
+repos:
+  meta-tegra-support:
+    path: ../tegra-demo-distro/layers/meta-tegra-support
+
+  meta-tegrademo:
+    path: ../tegra-demo-distro/layers/meta-tegrademo
+
+  meta-demo-ci:
+    path: ../tegra-demo-distro/layers/meta-demo-ci
+
+  meta-tegra:
+    path: ../tegra-demo-distro/repos/meta-tegra
+    url: https://github.com/OE4T/meta-tegra.git
+
+  meta-openembedded:
+    path: ../tegra-demo-distro/repos/meta-openembedded
+    url: https://git.openembedded.org/meta-openembedded
+    layers:
+      meta-filesystems:
+      meta-networking:
+      meta-python:
+      meta-oe:
+
+
+  meta-tegra-community:
+    path: ../repos/meta-tegra-community
+    url: https://github.com/OE4T/meta-tegra-community
+
+  meta-virtualization:
+    path: ../repos/meta-virtualization
+    url: https://git.yoctoproject.org/meta-virtualization
+
+  poky:
+    path: ../repos/poky
+    url: https://git.yoctoproject.org/poky
+    layers:
+      meta:
+
+local_conf_header:
+  tegra: |
+    # these two classes only work as intended when being inherited in the
+    # OE4t setup-env.sh style environment, as they modify bblayers.conf
+    # and expect additional information on the host.
+    INHERIT:remove = "tegra-support-sanity distro_layer_buildinfo"
+    EXTRA_IMAGE_FEATURES ?= "allow-empty-password empty-root-password allow-root-login"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md
@@ -9,6 +9,42 @@ also contains relevant images and submodules used to build tegra images.
 However, this is not strictly required.  The only dependency required
 is the [meta-tegra](https://github.com/OE4T/meta-tegra) layer.
 
+## Build with KAS
+
+The files under [conf/kas](conf/kas) support building with
+the [kas](https://kas.readthedocs.io/).
+
+The setups here represent the last configuration tested.
+
+### Install kas
+```
+pip3 install kas
+```
+
+### Build with kas
+
+Use the scripts at [scripts](scripts), for instance
+
+```
+./scripts/build-jetson-orin-nano-devkit-nvme.sh
+```
+to build for the jetson-orin-nano-devkit-nvme `MACHINE` on the
+default branch configuration.
+
+The default build will build for whatever branch of this
+repository you've cloned and latest branch of corresponding
+repositories.
+
+To build the latest tested configuration instead, use kas
+build to specify the swupdate-oe4t-lasttested.yml file from
+the base directory, for instance:
+
+```
+kas build layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t-lasttested.yml
+```
+You may need to modify the machine setting or set KAS_MACHINE appropriately.
+
+
 ## Build with tegra-demo-distro
 
 Use these instructions to add to tegra-demo-distro on whatever

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml
@@ -1,0 +1,20 @@
+header:
+  version: 14
+
+machine: jetson-orin-nano-devkit-nvme
+
+target:
+  - swupdate-image-tegra
+
+
+repos:
+  meta-swupdate:
+    url: https://github.com/sbabic/meta-swupdate
+    path: layers/meta-swupdate
+
+local_conf_header:
+    swupdate-tegra: |
+      IMAGE_INSTALL:append = " swupdate"
+      USE_REDUNDANT_FLASH_LAYOUT = "1"
+      IMAGE_FSTYPES:append = " tar.gz"
+      SWUPDATE_CORE_IMAGE_NAME ?= "demo-image-base"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/tegra-demo-distro-swupdate-lasttested.yml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/tegra-demo-distro-swupdate-lasttested.yml
@@ -1,0 +1,27 @@
+header:
+  version: 14
+
+repos:
+  meta-swupdate:
+    branch: master
+    commit: e7fdc1e09e816d0118a145068b7fff338d8bb3db
+
+  meta-tegra:
+    branch: master
+    commit: acb5907d2c6cf79b666fd7de631ef9518a2025fe
+
+  meta-openembedded:
+    branch: master
+    commit: c225779474d7f39db13ad5bba6850de7e8c41b8e
+
+  meta-tegra-community:
+    branch: master
+    commit: d95b55630470cd3c4c362e92fc42a97850dccce2
+
+  meta-virtualization:
+    branch: master
+    commit: 1640a4dc81f5d06a1e43c9870fefb2a0d016ef81
+
+  poky:
+    branch: master
+    commit: 7434b5428971576c6c1422d0a385084936ee9768

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t-lasttested.yml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t-lasttested.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t.yml
+    - layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/tegra-demo-distro-swupdate-lasttested.yml

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t.yml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml
+    - layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/scripts/build-jetson-orin-nano-devkit-nvme.sh
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/scripts/build-jetson-orin-nano-devkit-nvme.sh
@@ -1,0 +1,1 @@
+kasbuildbase.sh

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/scripts/kasbuildbase.sh
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/scripts/kasbuildbase.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+base=$(basename $0 .sh)
+machine=$(echo $base | cut -s -d '-' -f 2-)
+if [ ! -z "${machine}" ]; then
+    echo "building for machine ${machine}"
+    export KAS_MACHINE=${machine}
+fi
+base_layer_path=$(realpath $(dirname $0))/../
+echo "move to the base repo directory"
+pushd $(dirname $0)/../../../../../
+echo "Ensure we've setup submodules at least once"
+git submodule update --init --recursive
+kas build --update ${base_layer_path}/conf/kas/swupdate-oe4t.yml


### PR DESCRIPTION
This is the PR I've discussed for the past few monthly meetings.  It sets up a way to build the swupdate demo with either floating or fixed branches and an alternative to the setup-env script for building the demo distro.

It also provides an underlying `tegra-demo-distro.yml` configuration to build the demo distro standalone without swupdate, with command line like `kas build layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml`.  Projects in this or other repositories can extend `demo-image-base` or other recipes in this repo by including this config file in their kas configuration and without the need to fork this entire repo.

Full list of changes:

* Add a base tegra-demo-distro kas config as an alternative to using the setup-env option currently supported.
* Use the defaults setting in kas to let branches float to specific branch names.  Changing a single line in layers/meta-tegrademo/conf/kas/include/tegra-demo-distro-branch.yml should be all that is necessary to make layers float to specific tegra-demo-distro branches.
* Track the latest tested configurations of swupdate using kas files with a -lasttested.yml include file which overrides floating branch specifications to reference specific tested configs.
* Add build scripts to build swupdate using kas for supported branches, which allows creating symlinks with specified MACHINE names to override and build for alternate machines using the KAS_MACHINE environment variable.