### PR TITLE
swupdate: fix build target

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t.yml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/swupdate-oe4t.yml
@@ -1,5 +1,5 @@
 header:
   version: 14
   includes:
-    - layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml
     - layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml
+    - layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml


### PR DESCRIPTION
Fix ordering on swupdate-oe4t.yml to ensure the swupdate includes happen after the tegrademo includes.

Without this the target used by tegrademo base includes overrides the swupdate-tegra target and the swupdate .swu file is not built as a part of the build process.