### PR TITLE
swupdate: install-if-different bootloader support

### DIFF
--- a/layers/meta-tegrademo/conf/layer.conf
+++ b/layers/meta-tegrademo/conf/layer.conf
@@ -1,4 +1,4 @@
-BBPATH =. "${LAYERDIR}:"
+BBPATH =. "${LAYERDIR}:${LAYERDIR}/dynamic-layers/meta-swupdate:"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 BBFILES_DYNAMIC += "swupdate:${LAYERDIR}/dynamic-layers/meta-swupdate/recipes-*/*/*.bb \
                     swupdate:${LAYERDIR}/dynamic-layers/meta-swupdate/recipes-*/*/*.bbappend"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md
@@ -92,3 +92,25 @@ swupdate -i </path/to/swu/file>
   * The root partition should change
   * The `nvbootctrl dump-slots-info` output should show boot
 from the alternate boot slot with `Capsule update status:1`.
+
+# Build Options
+
+The tegra_swupdate.bbclass contains global configuration options
+for the swupdate demo.
+
+## TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT
+
+Set
+```
+TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT = "true"
+```
+in your local.conf or layer to only run the capsule update when
+a different bootloader version is detected in the alternate slot,
+where bootloader version is set based on ${L4T_VERSION} but can
+be modified by overriding variable `TEGRA_SWUPDATE_BOOTLOADER_VERSION`
+
+When this variable is set, the capsule payload will not be installed
+as a part of the update when the alternate partition is found to contain
+the same bootloader release version (rootfs was built with the same
+value of `TEGRA_SWUPDATE_BOOTLOADER_VERSION`.  Instead, the rootfs
+will be switched to the alternate rootfs.

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/classes-recipe/tegra_swupdate.bbclass
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/classes-recipe/tegra_swupdate.bbclass
@@ -1,0 +1,18 @@
+inherit l4t_version
+
+# Set to "true" to use logic which only installs the bootloader
+# when a change in L4T_VERSION is found between current and target rootfs
+TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT ?= "false"
+
+
+# The version written into the sw-versions file for the
+# bootloader update capsule, used to control bootloader
+# updates when TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT is "true"
+# Can be set to anything, but ideally would match the value
+# used for get_hex_bsp_version in tegra-uefi-capsule-signing.bbclass
+# to support comparisons with runtime checks of version in
+# /sys/firmware/efi/esrt/entries/entry0/fw_version
+TEGRA_SWUPDATE_BOOTLOADER_VERSION ?= "${L4T_VERSION}"
+
+
+TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH ?= "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -6,10 +6,9 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 SRC_URI = "\
     file://sw-description \
-    file://bootloader-update.lua \
 "
 
-inherit swupdate image_types_tegra
+inherit swupdate image_types_tegra tegra_swupdate
 
 DEPLOY_KERNEL_IMAGE ?= "${@os.path.basename(tegra_kernel_image(d))}"
 
@@ -21,17 +20,16 @@ SWUPDATE_CORE_IMAGE_NAME ?= "demo-image-base"
 
 ROOTFS_FILENAME ?= "${SWUPDATE_CORE_IMAGE_NAME}-${MACHINE}.rootfs.tar.gz"
 
-# Handle differences in redundant partition naming on t194 platforms
 KERNEL_A_PARTNAME = "A_kernel"
 KERNEL_A_DTB_PARTNAME = "A_kernel-dtb"
 KERNEL_B_PARTNAME = "B_kernel"
 KERNEL_B_DTB_PARTNAME = "B_kernel-dtb"
 
 # images to build before building swupdate image
-IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules"
+IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules tegra-swupdate-script"
 
 # images and files that will be included in the .swu image
 DTBFILE_PATH = "${@'${EXTERNAL_KERNEL_DEVICETREE}/${DTBFILE}' if len(d.getVar('EXTERNAL_KERNEL_DEVICETREE')) else '${DTBFILE}'}"
-SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH}"
+SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH} tegra-swupdate-script.lua"
 
 do_swuimage[depends] += "${DTB_EXTRA_DEPS}"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/bootloader-update.lua
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/bootloader-update.lua
@@ -1,5 +1,0 @@
-function postinst()
-    local success = os.execute("/usr/bin/oe4t-set-uefi-OSIndications")
-    local result = "oe4t-set-uefi-OSIndications completed with success: " .. tostring(success)
-    return success, result
-end

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
@@ -28,27 +28,30 @@ software =
 						sha256 = "$swupdate_get_sha256(@@ROOTFS_FILENAME@@)";
 					},
 					{
-                                                filename = "@@DEPLOY_KERNEL_IMAGE@@";
-                                                device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_B_PARTNAME@@";
-                                        },
-                                        {
-                                                filename = "@@DTBFILE@@";
-                                                device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_B_DTB_PARTNAME@@";
-                                        }
+						filename = "@@DEPLOY_KERNEL_IMAGE@@";
+						device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_B_PARTNAME@@";
+					},
+					{
+						filename = "@@DTBFILE@@";
+						device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_B_DTB_PARTNAME@@";
+					}
 
 				);
 				files: (
 					{
 						filename = "tegra-bl.cap";
-						path = "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap";
+						path = "@@TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@@";
 						properties = {create-destination = "true";}
+						name = "tegra-bootloader-capsule"
+						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
+						install-if-different = @@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@@
 					}
 				);
 				scripts: (
 					{
-						filename = "bootloader-update.lua";
+						filename = "tegra-swupdate-script.lua";
 						type = "lua"
-						sha256 = "$swupdate_get_sha256(bootloader-update.lua)";
+						sha256 = "$swupdate_get_sha256(tegra-swupdate-script.lua)";
 					}
 				);
 
@@ -76,26 +79,29 @@ software =
 						sha256 = "$swupdate_get_sha256(@@ROOTFS_FILENAME@@)";
 					},
 					{
-                                                filename = "@@DEPLOY_KERNEL_IMAGE@@";
-                                                device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_A_PARTNAME@@";
-                                        },
-                                        {
-                                                filename = "@@DTBFILE@@";
-                                                device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_A_DTB_PARTNAME@@";
-                                        }
+						filename = "@@DEPLOY_KERNEL_IMAGE@@";
+						device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_A_PARTNAME@@";
+					},
+					{
+						filename = "@@DTBFILE@@";
+						device = "@@ROOTFS_DEVICE_PATH@@/@@KERNEL_A_DTB_PARTNAME@@";
+					}
 				);
 				files: (
 					{
 						filename = "tegra-bl.cap";
-						path = "/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap";
+						path = "@@TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@@";
 						properties = {create-destination = "true";}
+						name = "tegra-bootloader-capsule"
+						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
+						install-if-different = @@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@@
 					}
 				);
 				scripts: (
 					{
-						filename = "bootloader-update.lua";
+						filename = "tegra-swupdate-script.lua";
 						type = "lua"
-						sha256 = "$swupdate_get_sha256(bootloader-update.lua)";
+						sha256 = "$swupdate_get_sha256(tegra-swupdate-script.lua)";
 					}
 				);
 			};

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/swupdate-machine-config/swupdate-genconfig.sh.in
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/swupdate-machine-config/swupdate-genconfig.sh.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+datadir=@DATADIR@
 get_current_slot() {
     curslot=$(nvbootctrl get-current-slot)
     if [ $curslot -eq 1 ]; then
@@ -20,6 +20,11 @@ else
 fi
 
 BOOTSLOT=$(get_current_slot)
+ALTROOTSLOT="APP"
+if [ "$BOOTSLOT" = "a" ]; then
+    ALTROOTSLOT="${ALTROOTSLOT}_b"
+fi
+
 
 rm -f /run/swupdate/swupdate.cfg
 
@@ -31,4 +36,18 @@ sed -e"s,@SWVERSION@,$VERSION_ID," \
     -e"s,@SERIALNUMBER@,$SERIALNUMBER," \
     -e"s,@BOOTSLOT@,$BOOTSLOT," \
     $extrased \
-    /usr/share/swupdate/swupdate.cfg.in > /run/swupdate/swupdate.cfg
+    /${datadir}/swupdate/swupdate.cfg.in > /run/swupdate/swupdate.cfg
+
+rm -f /run/swupdate/sw-versions
+alt_rootfs_dev="/dev/disk/by-partlabel/$ALTROOTSLOT"
+tmp_mount=`mktemp -d`
+mount -o ro $alt_rootfs_dev $tmp_mount
+if [ -e $tmp_mount/usr/share/swupdate/sw-versions-thisslot ]; then
+    echo "Setup sw-versions based on $ALTROOTSLOT"
+    cp $tmp_mount/${datadir}/swupdate/sw-versions-thisslot /run/swupdate/sw-versions
+else
+    echo "Alternate slot $ALTROOTSLOT does not contain sw-versions, using empty file"
+    touch /run/swupdate/sw-versions
+fi
+umount $tmp_mount
+rm -rf $tmp_mount

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/swupdate-machine-config_1.0.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/swupdate-machine-config_1.0.bb
@@ -2,9 +2,11 @@ DESCRIPTION = "Machine-specific configuration for swupdate"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+inherit tegra_swupdate
+
 SRC_URI = "\
     file://swupdate.cfg.in \
-    file://swupdate-genconfig.sh \
+    file://swupdate-genconfig.sh.in \
     file://swupdate-mods.conf \
 "
 
@@ -23,7 +25,10 @@ do_compile() {
     rm -f ${B}/hwrevision
     echo "${SWUPDATE_BOARDNAME} ${SWUPDATE_HWREVISION}" > ${B}/hwrevision
     sed -e's,@MODEL@,${SWUPDATE_BOARDNAME},g' \
-	${S}/swupdate.cfg.in > ${B}/swupdate.cfg.in
+	    ${S}/swupdate.cfg.in > ${B}/swupdate.cfg.in
+    sed -e's,@DATADIR@,${datadir},g' \
+	    ${S}/swupdate-genconfig.sh.in > ${B}/swupdate-genconfig.sh
+    echo "tegra-bootloader-capsule    ${TEGRA_SWUPDATE_BOOTLOADER_VERSION}" > ${B}/sw-versions-thisslot
 }
 
 do_install() {
@@ -33,9 +38,11 @@ do_install() {
     install -d ${D}${datadir}/swupdate
     install -m 0644 ${B}/swupdate.cfg.in ${D}${datadir}/swupdate/
     install -d ${D}${libexecdir}/swupdate
-    install -m 0755 ${S}/swupdate-genconfig.sh ${D}${libexecdir}/swupdate/swupdate-genconfig
+    install -m 0755 ${B}/swupdate-genconfig.sh ${D}${libexecdir}/swupdate/swupdate-genconfig
     install -d ${D}${sysconfdir}/systemd/system/swupdate.service.d
     install -m 0644 ${S}/swupdate-mods.conf ${D}${sysconfdir}/systemd/system/swupdate.service.d/
+    install -m 0644 ${B}/sw-versions-thisslot ${D}${datadir}/swupdate/
+    ln -s /run/swupdate/sw-versions ${D}${sysconfdir}/sw-versions
 }
 
 do_install:append:secureboot() {
@@ -43,6 +50,7 @@ do_install:append:secureboot() {
 }
 
 FILES:${PN} += "${datadir}/swupdate"
+FILES:${PN} += "${sysconfdir}/sw-versions"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 EXTRADEPS = "tegra-redundant-boot"
 RDEPENDS:${PN} += "${EXTRADEPS}"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/tegra-swupdate-script/tegra-swupdate-script.lua.in
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/tegra-swupdate-script/tegra-swupdate-script.lua.in
@@ -1,0 +1,57 @@
+local function get_current_slot()
+    local handle = io.popen("nvbootctrl get-current-slot")
+    if not handle then
+        print("Failed to get-current-slot")
+        return nil
+    end
+    local result = handle:read("*a")
+    handle:close()
+    return result:match("%d") -- Extracts the first digit found
+end
+
+local function set_active_slot(slot)
+    local command = "nvbootctrl set-active-boot-slot " .. slot
+    return os.execute(command)
+end
+
+local function switch_slots()
+    local current_slot = get_current_slot()
+    local success = -1
+    if current_slot then
+        local new_slot = current_slot == "1" and "0" or "1"
+        print("Switching active slot to: " .. new_slot)
+        success = set_active_slot(new_slot)
+    else
+        print("Failed to determine the current slot.")
+    end
+    return success
+end
+
+local function file_exists(path)
+    local file = io.open(path, "r")
+    if file then
+        file:close()
+        return true
+    else
+        return false
+    end
+end
+
+function postinst()
+    local success = -1
+    local result = ""
+    if file_exists("@TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@") then
+        print("Running bootloader update script")
+        success = os.execute("/usr/bin/oe4t-set-uefi-OSIndications")
+        result = "oe4t-set-uefi-OSIndications completed with status: " .. tostring(success)
+    else
+        if @TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@ then
+            print("Running os switch instead of bootloader update since @TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@ is missing")
+            success = switch_slots()
+            result = "switch_slots completed with status: " .. tostring(success)
+        else
+            result = "Missing @TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@, cannot complete update"
+        end
+    end
+    return success, result
+end

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/tegra-swupdate-script_1.0.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-support/swupdate/tegra-swupdate-script_1.0.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Script run as a part of swupdate install for tegra"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+    file://tegra-swupdate-script.lua.in \
+"
+
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+B = "${WORKDIR}/build"
+
+inherit tegra_swupdate deploy
+
+do_compile() {
+    sed -e's,@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@,${TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT},g' \
+        -e's,@TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@,${TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH},g'\
+        ${S}/tegra-swupdate-script.lua.in > ${B}/tegra-swupdate-script.lua
+}
+
+do_deploy() {
+    cp ${B}/tegra-swupdate-script.lua ${DEPLOYDIR}/
+}
+
+addtask deploy after do_install


### PR DESCRIPTION
As previously discussed since capsule update durations can be long on some platforms it may be beneficial to avoid capsule updates when the bootloader version does not change.

swupdate has a nice feature for this with [install-if-different](https://sbabic.github.io/swupdate/sw-description.html#checking-version-of-installed-software)

This PR adds a configuration feature for the swupdate demo `TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT`, defaulted to 'false' which when changed to `true` in local.conf or distro.conf, modifies to only switch the rootfs when the L4T version has not changed between the currently installed bootloader and the on-target bootloader, thereby speeding up the update process and avoiding the unnecessary bootloader capsule update.

# Commit Message

* add tegra_swupdate.bbclass for shared vars between swupdate components.  Add demo layer conf to support classes in meta-swupdate dynamic layer.
* Add TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT variable to control whether the `install-if-different` feature is used for the capsule image.
* Add a dedicated recipe for the tegra-swupdate-script and add support for detecting whether the capsule was installed.  If not installed, do a slot switch instead of requesting a capsule update on the next boot.