### PR TITLE
kas: fix paths to support external repos

### DIFF
--- a/layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml
+++ b/layers/meta-tegrademo/conf/kas/tegra-demo-distro.yml
@@ -1,8 +1,7 @@
 header:
   version: 14
   includes:
-    - repo: meta-tegrademo
-      file: conf/kas/include/tegra-demo-distro-branch.yml
+    - layers/meta-tegrademo/conf/kas/include/tegra-demo-distro-branch.yml
 
 distro: tegrademo
 
@@ -12,21 +11,18 @@ target:
 machine: jetson-orin-nano-devkit
 
 repos:
-  meta-tegra-support:
-    path: ../tegra-demo-distro/layers/meta-tegra-support
-
-  meta-tegrademo:
-    path: ../tegra-demo-distro/layers/meta-tegrademo
-
-  meta-demo-ci:
-    path: ../tegra-demo-distro/layers/meta-demo-ci
+  tegra-demo-distro:
+    layers:
+      layers/meta-tegra-support:
+      layers/meta-tegrademo:
+      layers/meta-demo-ci:
 
   meta-tegra:
-    path: ../tegra-demo-distro/repos/meta-tegra
+    path: repos/meta-tegra
     url: https://github.com/OE4T/meta-tegra.git
 
   meta-openembedded:
-    path: ../tegra-demo-distro/repos/meta-openembedded
+    path: repos/meta-openembedded
     url: https://git.openembedded.org/meta-openembedded
     layers:
       meta-filesystems:
@@ -36,15 +32,15 @@ repos:
 
 
   meta-tegra-community:
-    path: ../repos/meta-tegra-community
+    path: repos/meta-tegra-community
     url: https://github.com/OE4T/meta-tegra-community
 
   meta-virtualization:
-    path: ../repos/meta-virtualization
+    path: repos/meta-virtualization
     url: https://git.yoctoproject.org/meta-virtualization
 
   poky:
-    path: ../repos/poky
+    path: repos/poky
     url: https://git.yoctoproject.org/poky
     layers:
       meta:

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md
@@ -23,7 +23,13 @@ pip3 install kas
 
 ### Build with kas
 
-Use the scripts at [scripts](scripts), for instance
+Start by cloning this repo with
+
+```
+git clone <url> --shallow-submodules
+```
+
+Then use the scripts at [scripts](scripts) to kick of the build for instance
 
 ```
 ./scripts/build-jetson-orin-nano-devkit-nvme.sh

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/scripts/kasbuildbase.sh
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/scripts/kasbuildbase.sh
@@ -8,6 +8,6 @@ fi
 base_layer_path=$(realpath $(dirname $0))/../
 echo "move to the base repo directory"
 pushd $(dirname $0)/../../../../../
-echo "Ensure we've setup submodules at least once"
-git submodule update --init --recursive
+echo "Ensure we've initialized submodules before running kas on cloned repo with submodules"
+git submodule update --init --no-fetch --recommend-shallow
 kas build --update ${base_layer_path}/conf/kas/swupdate-oe4t.yml


### PR DESCRIPTION
With this commit I believe I now have a kas setup which will work either with build scripts inside this repo (such as the swupdate demo) and cloning building using the layout used for this repo or in scripts outside this repo, as demonstrated and tested on https://github.com/Trellis-Logic/kas-demos.

I've also optimized the getting started experience for someone deploying the kas instructions on the swupdate demo layer here.

# Commit Summary
* Fix relative paths to work with external kas includes
* Fix local path references to work with external kas includes
* Update swupdate README kas instructions to recommend shallow clones, since kas will update the subdirs as needed.
* Update base build script to run update with nofetch and shallow clone options, since we only need to ensure the submodule dirs are setup but don't care about the content, as kas will initialize for us