### PR TITLE
swupdate: support ESP partition updates

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -26,11 +26,13 @@ KERNEL_B_PARTNAME = "B_kernel"
 KERNEL_B_DTB_PARTNAME = "B_kernel-dtb"
 
 # images to build before building swupdate image
-IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules tegra-swupdate-script"
+IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules tegra-swupdate-script tegra-espimage"
+
+ESP_ARCHIVE ?= "${TEGRA_ESP_IMAGE}-${MACHINE}.tar.gz"
 
 # images and files that will be included in the .swu image
 DTBFILE_PATH = "${@'${EXTERNAL_KERNEL_DEVICETREE}/${DTBFILE}' if len(d.getVar('EXTERNAL_KERNEL_DEVICETREE')) else '${DTBFILE}'}"
-SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH} tegra-swupdate-script.lua"
+SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH} tegra-swupdate-script.lua ${ESP_ARCHIVE}"
 
 do_swuimage[depends] += "${DTB_EXTRA_DEPS}"
 

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -33,3 +33,8 @@ DTBFILE_PATH = "${@'${EXTERNAL_KERNEL_DEVICETREE}/${DTBFILE}' if len(d.getVar('E
 SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH} tegra-swupdate-script.lua"
 
 do_swuimage[depends] += "${DTB_EXTRA_DEPS}"
+
+# Add a link using the core image name.swu to the resulting swu image
+do_swuimage:append() {
+    os.symlink(d.getVar("IMAGE_NAME") + ".swu", d.getVar("SWUPDATE_CORE_IMAGE_NAME") + "-" + d.getVar("MACHINE") + ".swu")
+}

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra/sw-description
@@ -45,6 +45,15 @@ software =
 						name = "tegra-bootloader-capsule"
 						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
 						install-if-different = @@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@@
+					},
+					{
+						filename = "@@ESP_ARCHIVE@@"
+						type = "archive"
+						installed-directly = "true"
+						path = "/boot/efi"
+						name = "tegra-bootloader-capsule"
+						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
+						install-if-different = @@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@@
 					}
 				);
 				scripts: (
@@ -92,6 +101,15 @@ software =
 						filename = "tegra-bl.cap";
 						path = "@@TEGRA_SWUPDATE_CAPSULE_INSTALL_PATH@@";
 						properties = {create-destination = "true";}
+						name = "tegra-bootloader-capsule"
+						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
+						install-if-different = @@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@@
+					},
+					{
+						filename = "@@ESP_ARCHIVE@@"
+						type = "archive"
+						installed-directly = "true"
+						path = "/boot/efi"
 						name = "tegra-bootloader-capsule"
 						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
 						install-if-different = @@TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT@@


### PR DESCRIPTION
This PR adds two changes to the swupdate example in tegra demo distro:

1) A minor change to symlink the image name with .swu extension to make it easier for automated build scripts to find relevant artifacts and to match what other update tools use as naming conventions.
2) A change to support ESP partition updates, done conditionally only when the L4T version has changed if `TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT` is set to `true`.

# Commit Text for ESP Upgrade
Based on issues at [1] and [2] and discussions in the monthly
meetings at [3], [4], and [5] add an update to the L4TLauncher code
contained in the ESP partition boot directory.

Since this will not be brick-proof, make it conditional on
update-if-different logic also used for bootloader upgrades.  We
may want even stricter logic on when to use this copy if you are
especially concerned about brick-proof upgrades.

I considered using NVIDIA's scheme to use esp_alt partition and
the procedure outlined at [6].  However I decided not to go this
route because:
1) I think it still is not brick-proof, since the swapping of names
and partition GUIDs at [7] will not be atomic.
2) It adds complication to the variable update process, since the
ESP capsule needs to be aded to the partition to trigger capsule update,
so the esp alt partition swap would need to happen early in the update
process and then the alt partition would need modification before boot.

1: https://matrix.to/#/!YBfWVpJwNVtkmqVCPS:gitter.im/$WHyIkCEONvEDLukleV7gKtlUDp2-uMIHEflK7nRxw3Q?via=gitter.im&via=matrix.org&via=3dvisionlabs.com
2: https://github.com/orgs/OE4T/discussions/1874
3: https://github.com/OE4T/meta-tegra/wiki/OE4T-Meeting-Notes-2024%E2%80%9003%E2%80%9014
4: https://github.com/OE4T/meta-tegra/wiki/OE4T-Meeting-Notes-2024%E2%80%9005%E2%80%9009
5: https://github.com/OE4T/meta-tegra/wiki/OE4T-Meeting-Notes-2025%E2%80%9004%E2%80%9010
6: https://docs.nvidia.com/jetson/archives/r36.4.3/DeveloperGuide/SD/SoftwarePackagesAndTheUpdateMechanism.html#updating-the-esp-partition
7: https://github.com/Trellis-Logic/ota-tools-jetson/blob/f2418f3cfcadb8b9f3a0de166a40177256ae106a/Linux_for_Tegra/tools/ota_tools/version_upgrade/nv_ota_update_alt_part.func#L389-L398

# Testing

1. Tegraflash and boot an image built with this change and using the [swupdate instructions](https://github.com/OE4T/tegra-demo-distro/blob/master/layers/meta-tegrademo/dynamic-layers/meta-swupdate/README.md)
2. scp the `<imagename>.swu` file to the target from the deploy directory.
3. Run `swupdate -v -i <path to swu file>` to perform the upgrade.
3a. You should see a note like this indicating that the esp image has been installed
```
[TRACE] : SWUPDATE running :  [install_single_image] : Found installer for stream tegra-espimage-jetson-orin-nano-devkit-nvme.tar.gz archive
[TRACE] : SWUPDATE running :  [install_archive_image] : Installing file tegra-espimage-jetson-orin-nano-devkit-nvme.tar.gz on /boot/efi, ignoring attributes
```
4. Run `ls -la /boot/efi/EFI/BOOT/bootaa64.efi`
4a. The modification date/time should match the date/time of swupdate run, indicating this file was updated.
5. Reboot.
5a. The device should perform a capsule update during reboot
6. Run `nvbootctrl dump-slots-info`
6a. Status should show slot B and Capsule update status of 1.
7. Modify local.conf to set `TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT = "true"`
8. Build a new swupdate image with `bitbake swupdate-image-tegra`
9. scp the swupdate file to the device.
10. Run `swupdate -v -i <path to swu file>` to perform the upgrade.
10a. You should see notes like this indicating the extraction was skipped due to bootloader match
```
[TRACE] : SWUPDATE running :  [extract_files] : Found file
[TRACE] : SWUPDATE running :  [extract_files] :         filename tegra-espimage-jetson-orin-nano-devkit-nvme.tar.gz
[TRACE] : SWUPDATE running :  [extract_files] :         size 50025 Not required: skipping
```

