### PR TITLE
tegrademo-devicetree: add example for nano devkit

### DIFF
--- a/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree/tegra234-p3768-0000+p3767-0005-oe4t.dts
+++ b/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree/tegra234-p3768-0000+p3767-0005-oe4t.dts
@@ -1,0 +1,6 @@
+#include "tegra234-p3768-0000+p3767-0005-nv-super.dts"
+
+/* adds compatible string for oe4t, for demonstration purposes */
+/ {
+	compatible = "oe4t,p3768-0000+p3767-0005+tegrademo", "nvidia,p3768-0000+p3767-0005-super", "nvidia,p3767-0005", "nvidia,tegra234";
+};

--- a/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree_1.0.bb
+++ b/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree_1.0.bb
@@ -14,6 +14,7 @@ S = "${UNPACKDIR}"
 SRC_URI = "\
     file://tegra234-p3737-0000+p3701-0000-oe4t.dts \
     file://tegra234-p3768-0000+p3767-0000-oe4t.dts \
+    file://tegra234-p3768-0000+p3767-0005-oe4t.dts \
 "
 
 DT_INCLUDE = " \


### PR DESCRIPTION
The existing Orin Nano example is for the 16GB part. I'm not sure if it matters, but I thought adding one for the devkit would be a good procedure to go through in order to write up the instructions at [1].  This dts file works with the procedure there as tested on the jetson-orin-nano-devkit-nvme machine and Orin
Nano devkit setup.

I've also added a devicetree test case to the sheet at [2] referencing the wiki instructions and verified with R36.4.4.

1: https://github.com/OE4T/meta-tegra/wiki/Using-device-tree-overlays#example-out-of-tree-devicetree-in-tegra-demo-distro
2: https://docs.google.com/spreadsheets/d/1EWG5QZvtWdk74gz48D4xCbegK-bsqMFJ8XOsyGdUUeI/edit?gid=912773438#gid=912773438