### PR TITLE
swupdate: fix do_swuimage DTB depends

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -25,16 +25,22 @@ KERNEL_A_DTB_PARTNAME = "A_kernel-dtb"
 KERNEL_B_PARTNAME = "B_kernel"
 KERNEL_B_DTB_PARTNAME = "B_kernel-dtb"
 
-# images to build before building swupdate image
-IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-uefi-capsules tegra-swupdate-script tegra-espimage"
+# images to build before building swupdate image. For any non image depends, add to the do_swuimage[depends] instead.
+IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME} tegra-espimage"
 
 ESP_ARCHIVE ?= "${TEGRA_ESP_IMAGE}-${MACHINE}.tar.gz"
 
+# Prepend "devicetree" to the ${DTBFILE} in the images list, since this is the target for do_deploy
+# On the nvidia-kernel-oot-dtb recipe.
+DTBFILE_PATH = "devicetree/${DTBFILE}"
 # images and files that will be included in the .swu image
-DTBFILE_PATH = "${@'${EXTERNAL_KERNEL_DEVICETREE}/${DTBFILE}' if len(d.getVar('EXTERNAL_KERNEL_DEVICETREE')) else '${DTBFILE}'}"
 SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH} tegra-swupdate-script.lua ${ESP_ARCHIVE}"
 
-do_swuimage[depends] += "${DTB_EXTRA_DEPS}"
+# All non-image related depends go here
+do_swuimage[depends] += "${@'virtual/dtb:do_deploy' if d.getVar('PREFERRED_PROVIDER_virtual/dtb') else ''}"
+do_swuimage[depends] += "virtual/kernel:do_deploy"
+do_swuimage[depends] += "tegra-uefi-capsules:do_deploy"
+do_swuimage[depends] += "tegra-swupdate-script:do_deploy"
 
 # Add a link using the core image name.swu to the resulting swu image
 do_swuimage:append() {


### PR DESCRIPTION
Based on observations in [1] and [2], the inclusion of sysroots
for DTB depends can cause dependency issues during builds when
using rm_work.  The underlying cause of this may be a bug in
openembedded somewhere, but it's not obvious where.

We don't need the full sysroot for these targets, however, so
instead of using the do_populate_sysroot target set by tegra_dtb_extra_deps,
just use the do_deploy target for these packages instead. This
does not match what is typically done for image dependencies by swupdate in [3],
however see discussion in [4] for the rationale.

This puts the relevant DTB files in the deploy directory where we can access
them when building the swu file.

In addition, clean up the recipe for the update image to keep
non image recipes out of IMAGE_DEPENDS and instead add depends on
do_deploy for the relevant references.

Modify the DTBFILES path accordingly to reference the files in the
devicetree subdir of the deploy directory, where they are placed
by the devicetree recipe at [5]

1: https://github.com/OE4T/tegra-demo-distro/discussions/355
2: https://matrix.to/#/!YBfWVpJwNVtkmqVCPS:gitter.im/$ApSHa28z_9n3b7Pf1ad4j2Ew_ueOsdyQTZ6RjJFU5I4?via=gitter.im&via=matrix.org&via=3dvisionlabs.com
3: https://github.com/sbabic/meta-swupdate/blob/b0253e9cecccc47ebee31c71403957cccd941e0f/classes-recipe/swupdate-common.bbclass#L58-L64
4: https://github.com/OE4T/tegra-demo-distro/pull/360/files
5: https://github.com/OE4T/meta-tegra/blob/599bdd498ba9d16c96ec0c18c04fd0d2ebbe600d/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_36.4.4.bb#L22