### PR TITLE
tegrademo-devicetree: fix ordering of DT includes

### DIFF
--- a/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree_1.0.bb
+++ b/layers/meta-tegrademo/recipes-bsp/tegrademo-devicetree/tegrademo-devicetree_1.0.bb
@@ -22,8 +22,8 @@ DT_INCLUDE = " \
     ${RECIPE_SYSROOT}/usr/src/device-tree/nvidia/t23x/nv-public/include/kernel \
     ${RECIPE_SYSROOT}/usr/src/device-tree/nvidia/t23x/nv-public/include/nvidia-oot \
     ${RECIPE_SYSROOT}/usr/src/device-tree/nvidia/t23x/nv-public/include/platforms \
-    ${RECIPE_SYSROOT}/usr/src/device-tree/nvidia/t23x/nv-public \
     ${RECIPE_SYSROOT}/usr/src/device-tree/nvidia/t23x/nv-public/nv-platform \
+    ${RECIPE_SYSROOT}/usr/src/device-tree/nvidia/t23x/nv-public \
     ${S} \
     ${KERNEL_INCLUDE} \
 "


### PR DESCRIPTION
Files with the same name exists under t23x/nv-public and t23x/nv-public/nv-platform, with the current ordering some files from nv-public are used when those from nv-platform should be used, otherwise the content of the resulting dtb doesn't match the standard dtb for e.g. devkit

Verified by comparing AGXi devkit dtb from nvidia-kernel-oot with AGXi devkit dtb built using the devicetree recipe