### PR TITLE
distro/include/tegrademo.inc: remove duplicate includes

### DIFF
--- a/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
+++ b/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
@@ -43,12 +43,6 @@ SANITY_TESTED_DISTROS ?= " \
 # Most NVIDIA-supplied services expect systemd
 INIT_MANAGER = "systemd"
 
-require conf/distro/include/no-static-libs.inc
-require conf/distro/include/yocto-uninative.inc
-require conf/distro/include/security_flags.inc
-require conf/distro/include/yocto-space-optimize.inc
-INHERIT += "uninative"
-
 LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264"
 
 USE_REDUNDANT_FLASH_LAYOUT_DEFAULT ?= "0"


### PR DESCRIPTION
openembedded-core have included some default settings in conf/distro/defaultsetup.conf, for context see [1]-[5]. Remove those from tegrademo distro and avoid warnings about it.

  WARNING: Duplicate inclusion for <snip>/layers/meta/conf/distro/include/no-static-libs.inc in <snip>/layers/meta/conf/distro/defaultsetup.conf
  WARNING: Duplicate inclusion for <snip>/layers/meta/conf/distro/include/security_flags.inc in <snip>/layers/meta/conf/distro/defaultsetup.conf
  WARNING: Duplicate inclusion for <snip>layers/meta/conf/distro/include/yocto-space-optimize.inc in <snip>/layers/meta/conf/distro/defaultsetup.conf
  WARNING: Duplicate inclusion for <snip>layers/meta/conf/distro/include/yocto-uninative.inc in <snip>/layers/meta/conf/distro/defaultsetup.conf

[1] https://lists.openembedded.org/g/openembedded-architecture/message/2260
[2] https://git.openembedded.org/openembedded-core/commit/?id=722897f96d30e978b20e140419fb044d850f5c74
[3] https://git.openembedded.org/openembedded-core/commit/?id=03fc931bfe9ea3fa9f33553e6020cbc067b24291
[4] https://git.openembedded.org/openembedded-core/commit/?id=4c2d64c10a5b0437ab1ea04df22386f0f95124d1
[5] https://git.openembedded.org/openembedded-core/commit/?id=175fcf9fad699dd122680d3f6961af9bf8487046