### PR TITLE
[WIP] Add oeqa runtime test suite for Tegra images

### DIFF
--- a/layers/meta-tegrademo/conf/jetpack-6.2.env
+++ b/layers/meta-tegrademo/conf/jetpack-6.2.env
@@ -1,0 +1,4 @@
+# JetPack 6.2 / L4T R36.5.0 version floors. Source before oe-test.
+export TEGRA_L4T_MAJOR=36
+export TEGRA_CUDA_MIN=12.6
+export TEGRA_VPI_MAJOR=3

--- a/layers/meta-tegrademo/conf/jetpack-7.2.env
+++ b/layers/meta-tegrademo/conf/jetpack-7.2.env
@@ -1,0 +1,4 @@
+# JetPack 7.2 / L4T R39.2.0 version floors. Source before oe-test.
+export TEGRA_L4T_MAJOR=39
+export TEGRA_CUDA_MIN=13.2
+export TEGRA_VPI_MAJOR=4

--- a/layers/meta-tegrademo/conf/tegra-testexport.conf
+++ b/layers/meta-tegrademo/conf/tegra-testexport.conf
@@ -1,0 +1,5 @@
+# Off-host runtime testing via testexport. See docs/runtime-testing.md.
+
+IMAGE_CLASSES += "testexport"
+TEST_TARGET ?= "serial"
+TEST_SERIALCONTROL_CMD ?= "picocom -q -b 115200 /dev/ttyUSB0"

--- a/layers/meta-tegrademo/conf/tegra-testimage.conf
+++ b/layers/meta-tegrademo/conf/tegra-testimage.conf
@@ -1,0 +1,5 @@
+# On-host runtime testing via testimage. See docs/runtime-testing.md.
+
+IMAGE_CLASSES += "testimage"
+TEST_TARGET ?= "simpleremote"
+TEST_SUITES:append = " auto"

--- a/layers/meta-tegrademo/lib/oeqa/controllers/__init__.py
+++ b/layers/meta-tegrademo/lib/oeqa/controllers/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_identity.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_identity.py
@@ -1,0 +1,38 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraIdentityTest(OERuntimeTestCase):
+    """kernel version and devicetree identity checks."""
+
+    def test_kernel_version(self):
+        status, output = self.target.run("uname -r")
+        self.assertEqual(status, 0, msg="uname failed: %s" % output)
+        self.assertRegex(output.strip(), r"^\d+\.\d+\.\d+",
+                         msg="unexpected kernel version: %s" % output)
+
+    def test_devicetree_compatible(self):
+        # NUL-separated list; redirect avoids head exit masking a missing node
+        status, output = self.target.run(
+            "tr '\\000' '\\n' < /sys/firmware/devicetree/base/compatible")
+        if status != 0:
+            self.skipTest("no devicetree compatible node")
+        lines = [l.strip() for l in output.splitlines() if l.strip()]
+        if not lines:
+            self.skipTest("empty devicetree compatible node")
+        compatible = lines[0]
+        # nvidia, = stock; oe4t, = demo overlay prefix
+        self.assertRegex(compatible, r"^(nvidia|oe4t),[a-z0-9]",
+                         msg="unexpected board compatible: %s" % compatible)
+
+    def test_devicetree_model(self):
+        status, output = self.target.run(
+            "tr -d '\\000' < /sys/firmware/devicetree/base/model")
+        if status != 0:
+            self.skipTest("no devicetree model node")
+        self.assertRegex(output, r"(?i)jetson|orin|tegra|nvidia",
+                         msg="unexpected board model: %s" % output)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_versions.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_versions.py
@@ -1,0 +1,41 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import os
+import re
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraVersionsTest(OERuntimeTestCase):
+    """Floor-check L4T and CUDA versions against env vars."""
+
+    # source conf/jetpack-<release>.env before oe-test so the floors are set
+
+    def test_l4t_release(self):
+        status, output = self.target.run("cat /etc/nv_tegra_release 2>/dev/null")
+        self.assertTrue(status == 0 and output.strip(),
+                        msg="/etc/nv_tegra_release absent (nv-tegra-release not installed)")
+        m = re.search(r"R(\d+)\b.*?REVISION:\s*([\d.]+)", output)
+        self.assertIsNotNone(m, msg="unparseable L4T release: %s" % output)
+        want = os.environ["TEGRA_L4T_MAJOR"]
+        self.assertEqual(m.group(1), want,
+                         msg="L4T major %s != expected %s" % (m.group(1), want))
+
+    def test_cuda_version(self):
+        # meta-tegra ships no bare cuda symlink, so find the versioned toolkit dir
+        status, dirs = self.target.run("ls -d /usr/local/cuda-*/ 2>/dev/null")
+        if status != 0 or not dirs.strip():
+            self.skipTest("CUDA toolkit not installed (no /usr/local/cuda-* dir)")
+        nvcc = dirs.split()[0].rstrip("/") + "/bin/nvcc"
+        status, output = self.target.run("%s --version" % nvcc)
+        self.assertEqual(status, 0, msg="nvcc --version failed: %s" % output)
+        m = re.search(r"release\s+(\d+)\.(\d+)", output)
+        self.assertIsNotNone(m, msg="unparseable CUDA version: %s" % output[:500])
+        floor = os.environ["TEGRA_CUDA_MIN"]
+        got = tuple(int(x) for x in m.group(1, 2))
+        want = tuple(int(x) for x in floor.split(".")[:2])
+        self.assertGreaterEqual(got, want,
+                                msg="CUDA %s.%s below floor %s" % (m.group(1), m.group(2), floor))

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-common.inc
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-common.inc
@@ -6,6 +6,11 @@ inherit core-image
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-base packagegroup-demo-basetests"
 CORE_IMAGE_BASE_INSTALL += "${@'packagegroup-demo-systemd' if d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd' else ''}"
+# ship the L4T release-identity file (only the container toolkit pulls it otherwise)
+CORE_IMAGE_BASE_INSTALL += "nv-tegra-release"
 TOOLCHAIN_HOST_TASK += "nativesdk-packagegroup-cuda-sdk-host"
+
+# baseline suite; images add extras with TEST_SUITES:append
+TEST_SUITES = "tegra_identity tegra_versions"
 
 inherit nopackages


### PR DESCRIPTION
Adds oeqa test enablement for the Tegra demo images, plus initial identity and version checks. Still small but working on more tests.

To enable you require one of two conf fragments in your build's `local.conf`. `require conf/tegra-testexport.conf` builds a self-contained bundle (`bitbake <image> -c testexport`) that `oe-test` runs later on another host.

The cases are plain `OERuntimeTestCase`s, and the version checks read a floor from `conf/jetpack-{6.2,7.2}.env` rather than a pinned string (so should work on both JP6.2/JP7.2).

I've only had a Jetson Orin Nano devkit (R39.2.0) to try it on so far, results below. (Running the identity check is what flagged `nv-tegra-release` not being installed, so the image now pulls it in.) I'm also not sure meta-tegrademo is the right home versus keeping the generic infra in meta-tegra, so opinions welcome.

To try it: `require conf/tegra-testexport.conf`, `bitbake <image> -c testexport`, then run the bundle with `oe-test` (`--target-type serial` for a console-only DUT, or `simpleremote` over SSH).

Adding some results as well here.


