### PR TITLE
swupdate-image-tegra: fix DTBFILE reference

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra.bb
@@ -34,6 +34,7 @@ ESP_ARCHIVE ?= "${TEGRA_ESP_IMAGE}-${MACHINE}.tar.gz"
 
 # Prepend "devicetree" to the ${DTBFILE} in the images list, since this is the target for do_deploy
 # On the nvidia-kernel-oot-dtb recipe.
+DTBFILE = "${@os.path.basename(d.getVar('KERNEL_DEVICETREE').split()[0])}"
 DTBFILE_PATH = "devicetree/${DTBFILE}"
 # images and files that will be included in the .swu image
 SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap ${DEPLOY_KERNEL_IMAGE} ${DTBFILE_PATH} tegra-swupdate-script.lua ${ESP_ARCHIVE}"


### PR DESCRIPTION
DTBFILE definition was removed with [1], so add it here in the swupdate-image-tegra recipe instead.

Resolves
```
ERROR: swupdate-image-tegra-1.0-r0 do_swuimage: swupdate cannot find devicetree/${DTBFILE} image file
```

1: https://github.com/OE4T/meta-tegra/commit/97066c019a9a3a4b6537b25bd2f55953328fba30