### PR TITLE
dynamic-layers: configure nvidia runtime for docker

### DIFF
--- a/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
+++ b/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
@@ -46,6 +46,10 @@ INIT_MANAGER = "systemd"
 LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264"
 
 USE_REDUNDANT_FLASH_LAYOUT_DEFAULT ?= "1"
+
+# for docker-registry-config
+DOCKER_OCI_RUNTIMES ?= '{"nvidia":{"args":[],"path":"nvidia-container-runtime"}}'
+
 # XXX- until this is fixed in meta-oe
 EXTRA_OECMAKE:append:pn-jsoncpp = " -DCMAKE_CXX_STANDARD=17"
 # -XXX

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend
@@ -1,2 +1,3 @@
 REQUIRED_DISTRO_FEATURES:append = " virtualization"
-CORE_IMAGE_BASE_INSTALL += "docker nvidia-container-toolkit"
+IMAGE_FEATURES += "container-registry"
+CORE_IMAGE_BASE_INSTALL += "docker nvidia-container-toolkit docker-registry-config"


### PR DESCRIPTION
so docker recognizes --runtime=nvidia without the user having to manually run nvidia-ctk and restart the docker daemon.

Fixes #391 