### PR TITLE
demo-image-docker: add image

### DIFF
--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-docker-base.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-docker-base.bb
@@ -1,0 +1,6 @@
+SUMMARY = "Tegra demo base image with docker"
+DESCRIPTION = """A base image with docker, suitable for running basic docker container GPU passthrough tests. \
+For a full featured image with all possible pass through library files included, use demo-image-full instead."""
+
+require recipes-demo/images/demo-image-common.inc
+require demo-image-docker-minimal.inc

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-docker-minimal.inc
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-docker-minimal.inc
@@ -1,0 +1,3 @@
+REQUIRED_DISTRO_FEATURES:append = " virtualization"
+IMAGE_FEATURES += "container-registry"
+CORE_IMAGE_BASE_INSTALL += "docker nvidia-container-toolkit docker-registry-config"

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend
@@ -1,3 +1,1 @@
-REQUIRED_DISTRO_FEATURES:append = " virtualization"
-IMAGE_FEATURES += "container-registry"
-CORE_IMAGE_BASE_INSTALL += "docker nvidia-container-toolkit docker-registry-config"
+require demo-image-docker-minimal.inc


### PR DESCRIPTION
* Add demo-image-docker-base to create a baseline image suitable for running docker (and run-docker-tests) without everything in demo-image-full
* Create a demmo-image-docker-minimal.inc file which can be shared with the full image bbappend and track the minimal inclusion list for docker on tegra.

Verified this passes with https://github.com/OE4T/meta-tegra-community/pull/197
If' this looks good I'll update https://oe4t.github.io/master/NVIDIA-Container-Runtime-support.html#building to reference it.
