### PR TITLE
Add oeqa runtime test suite for Tegra images

### DIFF
--- a/layers/meta-tegrademo/conf/jetpack-6.2.env
+++ b/layers/meta-tegrademo/conf/jetpack-6.2.env
@@ -1,0 +1,5 @@
+# JetPack 6.2 / L4T R36.5.0. Source before oe-test.
+export TEGRA_L4T_MAJOR=36
+export TEGRA_L4T_MINOR=5.0
+export TEGRA_KERNEL_MIN=5.15
+export TEGRA_CUDA_MIN=12.6

--- a/layers/meta-tegrademo/conf/jetpack-7.2.env
+++ b/layers/meta-tegrademo/conf/jetpack-7.2.env
@@ -1,0 +1,5 @@
+# JetPack 7.2 / L4T R39.2.0. Source before oe-test.
+export TEGRA_L4T_MAJOR=39
+export TEGRA_L4T_MINOR=2.0
+export TEGRA_KERNEL_MIN=6.8
+export TEGRA_CUDA_MIN=13.2

--- a/layers/meta-tegrademo/conf/tegra-testexport.conf
+++ b/layers/meta-tegrademo/conf/tegra-testexport.conf
@@ -1,0 +1,5 @@
+# Off-host runtime testing via testexport. See docs/runtime-testing.md.
+
+IMAGE_CLASSES += "testexport"
+TEST_TARGET ?= "serial"
+TEST_SERIALCONTROL_CMD ?= "picocom -q -b 115200 /dev/ttyUSB0"

--- a/layers/meta-tegrademo/conf/tegra-testimage.conf
+++ b/layers/meta-tegrademo/conf/tegra-testimage.conf
@@ -1,0 +1,4 @@
+# On-host runtime testing via testimage. See docs/runtime-testing.md.
+
+IMAGE_CLASSES += "testimage"
+TEST_TARGET ?= "simpleremote"

--- a/layers/meta-tegrademo/docs/runtime-testing.md
+++ b/layers/meta-tegrademo/docs/runtime-testing.md
@@ -1,0 +1,175 @@
+# Tegra runtime testing
+
+meta-tegrademo ships an oeqa runtime test suite for Jetson/Tegra images. It is a
+set of `tegra_*` test cases plus the enablement to run them either off the build
+host (testexport) or on it (testimage). The suite mirrors OE4T's NVIDIA L4T release
+validation matrix and assumes no particular board, carrier, or recovery harness.
+
+## What is here
+
+```
+lib/oeqa/runtime/cases/tegra_*.py        the test cases
+lib/oeqa/runtime/cases/parselogs-ignores-tegra.txt   dmesg-noise allowlist for parselogs
+lib/oeqa/controllers/tegratarget.py      optional testimage controller (flash + power)
+conf/tegra-testexport.conf               enable off-host testing (require it)
+conf/tegra-testimage.conf                enable on-host testing (require it)
+conf/jetpack-{6.2,7.2}.env               per-release version floors
+```
+
+The bench is assumed fully wired: RJ45, USB storage, a DisplayPort monitor, and
+cameras all attached. A test runs on the images that ship the feature it exercises
+(see the table below) and fails loudly when that feature is present but broken.
+Hardware that is attached but not working (a driver that fails to bind, a monitor
+that returns no EDID) is a failure, never a skip and never a pass. A case skips
+only when its peripheral is genuinely absent, when the transport is serial-only
+(the reboot, deep-sleep, and swupdate cycles need SSH to reconnect), or when its
+content is package-gated and not installed.
+
+## Two ways to run
+
+`testexport` and `testimage` run the same `TEST_SUITES`; they differ in where and
+when the tests execute.
+
+- **testexport (off-host).** `bitbake <image> -c testexport` builds a
+  self-contained bundle that `oe-test` runs later, elsewhere, with no build tree.
+  It supports the `serial` target (a console-only DUT with no network) and the
+  `simpleremote` target (SSH). This is the path for a laptop or a flashing rig
+  that is separate from the build farm, and for running one bundle across many
+  boards. No controller is involved.
+- **testimage (on-host).** `bitbake <image> -c testimage` runs the suite on the
+  build host immediately after the build, against a running board reached over
+  SSH. Use it for CI gating. The `TegraTarget` controller can additionally flash
+  and power-cycle the board first (see below).
+
+Enable either (or both) by requiring the matching fragment in the build's
+`conf/local.conf`:
+
+```
+require conf/tegra-testexport.conf
+require conf/tegra-testimage.conf
+```
+
+## Per-image suites
+
+Each demo image runs the baseline from `demo-image-common.inc` plus the extras
+its components need, appended in the image recipe.
+
+| Image | Adds over the baseline |
+| --- | --- |
+| demo-image-egl | `tegra_gstreamer`, `tegra_camera` |
+| demo-image-sato, demo-image-weston | the above plus `tegra_vulkan` |
+| demo-image-full | the above plus `tegra_vpi`, `tegra_mmapi`, `tegra_opencv`, `tegra_tensorrt`, `tegra_capsule`, `tegra_docker`, and `tegra_deepstream` (docker arrives via the meta-virtualization bbappend; the gated suites self-skip until their content is installed) |
+
+The swupdate kas fragment adds `tegra_swupdate` on the redundant-layout image.
+
+### Optional test packages
+
+Some validation rows need content the demo images do not carry by default, either
+because it is large (DeepStream, the L4T ML containers) or build-option gated (the
+OpenCV CUDA modules). Install the package in the image under test and the matching
+case runs; leave it out and the case skips. Add them in `local.conf`:
+
+| Add to the image | Enables |
+| --- | --- |
+| the `libopencv-cuda*` modules | `tegra_opencv` |
+| `deepstream-tests` | `tegra_deepstream` |
+| `nvidia-docker-tests` | `tegra_docker` (the GPU-container test) |
+| `docker nvidia-container-toolkit` (with `meta-virtualization`) | `tegra_docker` |
+
+```
+IMAGE_INSTALL:append = " deepstream-tests nvidia-docker-tests \
+    libopencv-cudaarithm libopencv-cudabgsegm libopencv-cudacodec \
+    libopencv-cudafeatures2d libopencv-cudafilters libopencv-cudaimgproc \
+    libopencv-cudalegacy libopencv-cudaobjdetect libopencv-cudaoptflow \
+    libopencv-cudastereo libopencv-cudawarping"
+```
+
+`tegra_docker` needs the docker engine and the nvidia container runtime; on
+`demo-image-full` those come from the
+`dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend`.
+`tegra_docker`'s GPU-container test adds `nvidia-docker-tests`, whose `run-docker-tests`
+runs a GPU workload in the CUDA, PyTorch and TensorFlow NGC containers. It fails hard when
+the board cannot reach `nvcr.io`.
+
+`core-image-minimal` is not owned by this layer; set its suite in `local.conf` to
+run the peripheral-free baseline.
+
+```
+TEST_SUITES:pn-core-image-minimal = "tegra_identity tegra_versions tegra_storage \
+    tegra_thermal tegra_boottime tegra_console tegra_usb tegra_network \
+    tegra_watchdog tegra_esrt tegra_partition tegra_nvpmodel tegra_kmodule \
+    tegra_nvbootctrl tegra_overlay tegra_display tegra_reboot tegra_suspend"
+```
+
+The baseline `TEST_SUITES` leads with a small, relevant slice of oe-core cases
+(`ping ssh date df oe_syslog`) instead of the full `auto` set, which would pull in
+many cases that do not apply to these images (connman, RT, MMC, rtcwake, ...).
+`parselogs` is omitted until `parselogs-ignores-tegra.txt` is curated against the
+benign L4T driver noise.
+
+### Off-host quick start (serial, no network)
+
+```
+# in local.conf:
+#   require conf/tegra-testexport.conf
+bitbake demo-image-base -c testexport
+```
+
+The bundle lands in `tmp/testexport/<image>/` (some configurations place it under
+`tmp/testimage/<image>/`). Flash and boot the board by hand (standard
+`initrd-flash`), make sure the image offers a root shell on its console, then run
+the bundle anywhere with Python and `pexpect`:
+
+```
+cd tmp/testexport/demo-image-base
+. .../conf/jetpack-7.2.env   # exports the TEGRA_* version floors the tests assert
+./oe-test runtime --target-type serial --json-result-dir . \
+    */lib/oeqa/runtime/cases
+```
+
+The `conf/jetpack-{6.2,7.2}.env` files export the per-release floors
+(`TEGRA_L4T_MAJOR/MINOR`, `TEGRA_KERNEL_MIN`, `TEGRA_CUDA_MIN`) that
+`tegra_identity` and `tegra_versions` read from the environment; source the one
+for the release under test before `oe-test`.
+
+`oe-test` drives the DUT shell through `TEST_SERIALCONTROL_CMD` (a transparent
+console bridge such as `picocom -q`, `socat`, or `microcom`, never `minicom`,
+whose UI corrupts the stream). Set it for your console device; the value baked
+into the bundle is only a placeholder. The oeqa serial target does not log in, so
+leave the board at a logged-in root shell, or use an image with serial root
+autologin.
+
+For an SSH bundle instead, add the oe-core slice at build time
+(`TEST_SUITES:append = " ping ssh date df oe_syslog"`, which `export-parity.sh`
+injects) and run with `--target-type simpleremote --target-ip <DUT>`. The reboot,
+deep-sleep, capsule, and swupdate cycles reconnect after the board drops, so they
+run only on this SSH path and self-skip on serial; SC7 wakes itself via the RTC
+(R36.4.3 or newer) and `tegra_swupdate` needs the redundant-layout image.
+`tegra_reboot` repeats `TEGRA_REBOOT_CYCLES` times (default 3; the full validation
+matrix sets it higher). The board is reached over its RJ45 NIC (or any working
+network interface).
+
+### Automated flashing
+
+To make `testimage` flash and power-cycle the board first, set `TEST_TARGET = "TegraTarget"` (`lib/oeqa/controllers/tegratarget.py`). It is hardware-agnostic; recovery, flash, and power run through commands you supply, so any harness works and none is required.
+
+testimage forwards `TEST_POWERCONTROL_CMD` to the controller but not the flash command, so flash settings come from the environment.
+
+```
+# in local.conf:
+TEST_TARGET = "TegraTarget"
+TEST_TARGET_IP = "<dut-ip-or-hostname>"            # the booted DUT, for the test SSH
+TEST_POWERCONTROL_CMD = "/path/to/power-control"   # invoked with on|off|cycle
+
+# in the environment, before bitbake <image> -c testimage:
+export TEST_FLASHCONTROL_CMD="/path/to/flash-control"   # invoked with the artifact path
+export TEST_FLASHCONTROL_ARTIFACT="$DEPLOY_DIR_IMAGE/<image>-<machine>.rootfs.tegraflash-tar.zst"
+# export TEST_RCM_BOOT_TIMEOUT=300
+```
+
+`start()` flashes (when a flash command is set; otherwise the board is assumed
+already flashed), runs `TEST_POWERCONTROL_CMD on`, and waits for the DUT to answer
+over SSH; `stop()` runs `TEST_POWERCONTROL_CMD off`. Because the suite runs over
+SSH, the DUT must be networked once booted; the no-network case stays on the
+off-host serial path. With no harness, oe-core's `dialog-power-control` gives a
+manual power prompt.

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/conf/kas/include/swupdate-base.yml
@@ -18,3 +18,4 @@ local_conf_header:
       USE_REDUNDANT_FLASH_LAYOUT = "1"
       IMAGE_FSTYPES:append = " tar.gz"
       SWUPDATE_CORE_IMAGE_NAME ?= "demo-image-base"
+      TEST_SUITES:append = " tegra_swupdate"

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-demo/images/demo-image-full.bbappend
@@ -1,1 +1,4 @@
 require demo-image-docker-minimal.inc
+
+# tegra_docker only where docker + the nvidia runtime are installed
+TEST_SUITES:append = " tegra_docker"

--- a/layers/meta-tegrademo/lib/oeqa/controllers/__init__.py
+++ b/layers/meta-tegrademo/lib/oeqa/controllers/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/layers/meta-tegrademo/lib/oeqa/controllers/tegratarget.py
+++ b/layers/meta-tegrademo/lib/oeqa/controllers/tegratarget.py
@@ -1,0 +1,63 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import subprocess
+import time
+
+from oeqa.core.target.ssh import OESSHTarget
+
+
+class TegraTarget(OESSHTarget):
+
+    def __init__(self, logger, ip, server_ip, powercontrol_cmd=None,
+                 powercontrol_extra_args="", **kwargs):
+        super(TegraTarget, self).__init__(logger, ip, server_ip, **kwargs)
+        self.powercontrol_cmd = powercontrol_cmd
+        if powercontrol_cmd and powercontrol_extra_args:
+            self.powercontrol_cmd = "%s %s" % (powercontrol_cmd, powercontrol_extra_args)
+        self.flashcontrol_cmd = os.environ.get("TEST_FLASHCONTROL_CMD") or None
+        self.flash_artifact = os.environ.get("TEST_FLASHCONTROL_ARTIFACT") or None
+        self.boot_timeout = int(os.environ.get("TEST_RCM_BOOT_TIMEOUT") or "300")
+
+    def _host_cmd(self, cmd):
+        # runs on the host, not the DUT.
+        self.logger.info("TegraTarget host: %s" % cmd)
+        return subprocess.call(cmd, shell=True)
+
+    def _power(self, action):
+        # on/off/cycle appended as final arg (oe-core convention).
+        if self.powercontrol_cmd:
+            self._host_cmd("%s %s" % (self.powercontrol_cmd, action))
+
+    def _flash(self):
+        if not self.flashcontrol_cmd or not self.flash_artifact:
+            self.logger.info("TegraTarget: no TEST_FLASHCONTROL_CMD/ARTIFACT in the "
+                             "environment; assuming the board is already flashed")
+            return
+        self.logger.info("TegraTarget: recovering and flashing %s" % self.flash_artifact)
+        rc = self._host_cmd("%s %s" % (self.flashcontrol_cmd, self.flash_artifact))
+        if rc != 0:
+            raise AssertionError("flash command returned %d: %s %s"
+                                 % (rc, self.flashcontrol_cmd, self.flash_artifact))
+
+    def _wait_for_ssh(self):
+        # initrd-flash plus first boot is slow, so use a generous boot timeout.
+        deadline = time.time() + self.boot_timeout
+        while time.time() < deadline:
+            status, _ = self.run("true", timeout=30, ignore_ssh_fails=True)
+            if status == 0:
+                return
+            time.sleep(5)
+        raise AssertionError("DUT %s did not answer over SSH within %ds"
+                             % (self.ip, self.boot_timeout))
+
+    def start(self, **kwargs):
+        self._flash()
+        self._power("on")
+        self._wait_for_ssh()
+
+    def stop(self, **kwargs):
+        self._power("off")

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/parselogs-ignores-tegra.txt
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/parselogs-ignores-tegra.txt
@@ -1,0 +1,1 @@
+# tegra parselogs ignore list (loaded for "tegra" machines).

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_boottime.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_boottime.py
@@ -1,0 +1,53 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import time
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.core.decorator.depends import OETestDepends
+
+class TegraBootTest(OERuntimeTestCase):
+    """System reached a healthy state after boot."""
+
+    SYSTEMCTL = "SYSTEMD_BUS_TIMEOUT=300s systemctl"
+
+    def _failed_units(self):
+        _, failed = self.target.run(
+            "COLUMNS=400 SYSTEMD_COLORS=0 %s list-units --state=failed "
+            "--no-legend --plain --no-pager | awk '{print $1}'" % self.SYSTEMCTL)
+        return failed
+
+    # no dependency: the state-changing cases depend on boottime, not the reverse
+    def test_system_running(self):
+        status, output = self.target.run("command -v systemctl")
+        self.assertEqual(status, 0,
+                         msg="systemctl not found on demo-image-full: %s" % output)
+        # poll up to 3 min; a fresh-flash first boot settles slower (first-boot
+        # services and the OTA bootloader-update verifier) than a warm reboot
+        state = ""
+        endtime = time.time() + 180
+        while True:
+            _, state = self.target.run("%s is-system-running" % self.SYSTEMCTL)
+            state = state.strip()
+            if state.startswith(("running", "degraded")):
+                break
+            if time.time() >= endtime:
+                break
+            time.sleep(5)
+        failed = self._failed_units() if state == "degraded" else ""
+        self.assertRegex(state, r"^(running|degraded)",
+                         msg="system not running/degraded after wait: %s\nfailed units:\n%s"
+                             % (state, failed))
+
+    @OETestDepends(['tegra_boottime.TegraBootTest.test_system_running'])
+    def test_no_failed_units(self):
+        # networkd-wait-online is benign when the bench has no DHCP for this NIC
+        benign = {"systemd-networkd-wait-online.service"}
+        real = [u for u in self._failed_units().split() if u and u not in benign]
+        if real:
+            _, detail = self.target.run(
+                "%s status --full --failed --no-pager" % self.SYSTEMCTL)
+            self.fail("failed systemd units after boot: %s\n%s" % (" ".join(real), detail))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_camera.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_camera.py
@@ -1,0 +1,55 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraCameraTest(OERuntimeTestCase):
+    """Argus CSI capture (e.g. IMX219) with a camera attached; headless."""
+
+    NUM_BUFFERS = 10
+
+    def _require_argus(self):
+        # match the plugin listing; a bare gst-inspect of a missing element exits 255 and
+        # reads as a dropped connection on the remote target
+        status, _ = self.target.run("gst-inspect-1.0 2>/dev/null | grep -qw nvarguscamerasrc")
+        self.assertEqual(status, 0, msg="nvarguscamerasrc element not registered; plugin packaging gap")
+        if self.target.run("test -S /tmp/argus_socket")[0] != 0:
+            self.skipTest("no nvargus-daemon socket; no CSI camera on this board")
+
+    def _capture(self, sensor_id):
+        self._require_argus()
+        # nvarguscamerasrc exits non-zero on a benign teardown error; judge by the Argus log markers
+        _, output = self.target.run(
+            "gst-launch-1.0 nvarguscamerasrc sensor-id=%d num-buffers=%d "
+            "! 'video/x-raw(memory:NVMM)' ! fakesink" % (sensor_id, self.NUM_BUFFERS))
+        if "no cameras available" in output.lower():
+            self.skipTest("no CSI sensor on sensor-id=%d" % sensor_id)
+        self.assertIn("Starting repeat capture requests", output,
+                      msg="Argus did not start capturing on sensor-id=%d:\n%s"
+                          % (sensor_id, output[-2000:]))
+        self.assertIn("Got EOS", output,
+                      msg="capture did not reach EOS (no frames flowed) on sensor-id=%d:\n%s"
+                          % (sensor_id, output[-2000:]))
+
+    def test_argus_capture_sensor0(self):
+        self._capture(0)
+
+    def test_argus_capture_sensor1(self):
+        self._capture(1)
+
+    def test_argus_jpeg(self):
+        self._require_argus()
+        jpg = "/tmp/tegra-argus.jpg"
+        self.target.run("rm -f %s" % jpg)
+        _, output = self.target.run(
+            "gst-launch-1.0 nvarguscamerasrc sensor-id=0 num-buffers=1 ! "
+            "nvvidconv ! nvjpegenc ! filesink location=%s" % jpg)
+        if "no cameras available" in output.lower():
+            self.skipTest("no CSI sensor on sensor-id=0")
+        status, _ = self.target.run("test -s %s" % jpg)
+        self.target.run("rm -f %s" % jpg)
+        self.assertEqual(status, 0,
+                         msg="argus capture produced no JPEG artifact (no real image saved)")

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_capsule.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_capsule.py
@@ -1,0 +1,67 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from tegra_reconnect import TegraReconnect
+from oeqa.runtime.decorator.package import OEHasPackage
+from oeqa.core.decorator.depends import OETestDepends
+from oeqa.core.target.ssh import OESSHTarget
+
+class TegraCapsuleTest(TegraReconnect, OERuntimeTestCase):
+    """UEFI capsule update of the non-current bootloader slot."""
+
+    BOOT_TIMEOUT = 600
+    ESP = "/boot/efi"
+    CAPSULE = "/opt/nvidia/UpdateCapsule/tegra-bl.cap"
+
+    def _dump_slots_info(self):
+        status, info = self.target.run("nvbootctrl dump-slots-info")
+        self.assertEqual(status, 0, msg="nvbootctrl dump-slots-info failed: %s" % info)
+        return info
+
+    @OEHasPackage(["tegra-uefi-capsules"])
+    @OETestDepends(['tegra_esrt.TegraEsrtTest.test_esrt_present',
+                    'tegra_boottime.TegraBootTest.test_system_running'])
+    def test_capsule_update_cycle(self):
+        if not isinstance(self.target, OESSHTarget):
+            self.skipTest("capsule update needs an SSH target; serial cannot reconnect")
+
+        status, _ = self.target.run("test -f %s" % self.CAPSULE)
+        self.assertEqual(status, 0,
+                         msg="capsule payload %s missing despite tegra-uefi-capsules" % self.CAPSULE)
+
+        before = self._dump_slots_info()
+        self.assertRegex(before, r"(?mi)^\s*Capsule update status:\s*0\b",
+                         msg="capsule status not 0 before update:\n%s" % before)
+
+        status, out = self.target.run(
+            "mkdir -p %s/EFI/UpdateCapsule && cp %s %s/EFI/UpdateCapsule/ && sync"
+            % (self.ESP, self.CAPSULE, self.ESP))
+        self.assertEqual(status, 0, msg="cannot stage the capsule on the ESP: %s" % out)
+
+        # request capsule-on-disk processing on the next boot
+        status, out = self.target.run("oe4t-set-uefi-OSIndications")
+        self.assertEqual(status, 0, msg="cannot set the OsIndications capsule bit: %s" % out)
+
+        boot_before = self._boot_id()
+        self.assertTrue(boot_before, msg="could not read boot_id before the capsule reboot")
+        self.target.run("reboot", timeout=10, ignore_ssh_fails=True)
+        self.assertTrue(self._wait_for_new_boot(boot_before),
+                        msg="board did not reboot and return within %ds after the capsule" % self.BOOT_TIMEOUT)
+
+        after = self._dump_slots_info()
+        self.assertRegex(after, r"(?mi)^\s*Capsule update status:\s*1\b",
+                         msg="capsule update status not 1 after reboot (apply failed):\n%s" % after)
+
+        # every FMP entry must report success; a failed capsule leaves its entry non-zero,
+        # so checking that no entry failed catches it without parsing the capsule's GUID
+        status, st = self.target.run(
+            "cat /sys/firmware/efi/esrt/entries/entry*/last_attempt_status")
+        self.assertEqual(status, 0, msg="no ESRT entries; capsule path not firmware-backed")
+        failed = [v for v in st.split() if v.strip() != "0"]
+        self.assertEqual(failed, [],
+                         msg="an ESRT entry reports a failed capsule update "
+                             "(last_attempt_status != 0):\n%s" % st)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_console.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_console.py
@@ -1,0 +1,42 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import re
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+# TCU=Orin, UTC=Thor, AMA=AGX PL011, S=8250; THS is device-node only (not a console)
+_CONSOLE_RE = re.compile(r"(?m)^tty(TCU|UTC|S|AMA)\d+\b")
+_DEVNODE_RE = re.compile(r"^/dev/tty(TCU|UTC|THS|S|AMA)\d+$")
+
+class TegraSerialConsoleTest(OERuntimeTestCase):
+    """kernel serial console is registered on a Tegra UART."""
+
+    def test_serial_console_registered(self):
+        status, output = self.target.run("cat /proc/consoles")
+        self.assertEqual(status, 0, msg=output)
+        self.assertTrue(_CONSOLE_RE.search(output),
+                        msg="no Tegra serial console in /proc/consoles: %s" % output)
+
+    def test_serial_device_node(self):
+        _, output = self.target.run("ls /dev/tty* 2>/dev/null")
+        nodes = [l for l in output.split() if _DEVNODE_RE.match(l)]
+        self.assertTrue(nodes, msg="no Tegra serial device node present: %s" % output)
+
+    def test_serial_getty_enabled(self):
+        status, output = self.target.run("cat /proc/consoles")
+        self.assertEqual(status, 0, msg="could not read /proc/consoles: %s" % output)
+        self.assertTrue(_CONSOLE_RE.search(output),
+                        msg="no Tegra serial console in /proc/consoles: %s" % output)
+        devs = [line.split()[0] for line in output.splitlines()
+                if _CONSOLE_RE.match(line)]
+        for dev in devs:
+            status, state = self.target.run(
+                "systemctl is-enabled serial-getty@%s.service" % dev)
+            if status == 0 or state.strip() in ("enabled", "static", "alias", "indirect"):
+                return
+        self.fail(
+            "no serial-getty enabled for Tegra console(s) %s" % ", ".join(devs))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_deepstream.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_deepstream.py
@@ -1,0 +1,22 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OEHasPackage
+
+class TegraDeepstreamTest(OERuntimeTestCase):
+    """DeepStream sample apps via run-deepstream-tests."""
+
+    @OEHasPackage(["deepstream-tests"])
+    def test_deepstream(self):
+        status, output = self.target.run("run-deepstream-tests", timeout=1800)
+        self.assertEqual(status, 0,
+                         msg="run-deepstream-tests reported failures:\n%s" % output[-2000:])
+        self.assertRegex(output, r"Tests failed:\s+0",
+                         msg="run-deepstream-tests summary not clean:\n%s" % output[-2000:])
+        # reject the all-skip false-pass (a stale DEEPSTREAM_PATH skips every sub-test yet exits 0)
+        self.assertRegex(output, r"Tests passed:\s+[1-9]",
+                         msg="run-deepstream-tests: no sub-tests passed (all skipped or none ran):\n%s" % output[-2000:])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_display.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_display.py
@@ -1,0 +1,30 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OEHasPackage
+
+class TegraDisplayTest(OERuntimeTestCase):
+    """DRM is up and a monitor is detected on the display output."""
+
+    def test_drm_device_present(self):
+        status, output = self.target.run("ls /sys/class/drm/ 2>/dev/null")
+        self.assertTrue(status == 0 and "card" in output,
+                        msg="no DRM subsystem (no /sys/class/drm/card*); display driver not loaded")
+        self.assertRegex(output, r"card\d+", msg="no DRM device: %s" % output)
+
+    @OEHasPackage(["xrandr"])
+    def test_display_connected(self):
+        # xrandr-gated, so this runs only on the X11 images (xrandr comes with x11-base),
+        # where Xorg is up; a dead Xorg makes xrandr fail and the test fail, as intended
+        X = "DISPLAY=:0 XAUTHORITY=/root/.Xauthority"
+        status, output = self.target.run("%s xrandr --query" % X)
+        self.assertEqual(status, 0, msg="xrandr query failed:\n%s" % output)
+        self.assertRegex(output, r"(DP|HDMI)[-0-9]* connected",
+                         msg="no DP/HDMI output connected; bench monitor missing or not detected:\n%s" % output)
+        _, verbose = self.target.run("%s xrandr --verbose" % X)
+        self.assertRegex(verbose, r"EDID:\s*\n\s+00ffffffffffff00",
+                         msg="no valid EDID on the connected output:\n%s" % verbose[-1500:])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_docker.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_docker.py
@@ -1,0 +1,35 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OEHasPackage
+from oeqa.core.decorator.depends import OETestDepends
+
+class TegraDockerTest(OERuntimeTestCase):
+    """docker daemon, the nvidia container runtime, and a GPU workload in a container."""
+
+    @OEHasPackage(["docker-moby"])
+    def test_docker_daemon(self):
+        status, output = self.target.run("docker info")
+        self.assertEqual(status, 0, msg="docker daemon not responsive:\n%s" % output[-2000:])
+
+    @OEHasPackage(["docker-moby"])
+    @OETestDepends(['tegra_docker.TegraDockerTest.test_docker_daemon'])
+    def test_nvidia_runtime(self):
+        for tool in ("nvidia-ctk", "nvidia-container-runtime"):
+            self.assertEqual(self.target.run("command -v %s" % tool)[0], 0,
+                             msg="%s missing; nvidia-container-toolkit packaging gap" % tool)
+        status, out = self.target.run("docker info -f '{{json .Runtimes}}'")
+        self.assertIn("nvidia", out,
+                      msg="nvidia runtime not registered; check nvidia-container-setup.service:\n%s" % out)
+
+    @OEHasPackage(["nvidia-docker-tests"])
+    @OETestDepends(['tegra_docker.TegraDockerTest.test_nvidia_runtime'])
+    def test_docker_gpu(self):
+        # run-docker-tests pulls and runs the NGC GPU containers; it fails hard when the
+        # board cannot reach nvcr.io (the bench is assumed networked, per the suite policy)
+        status, output = self.target.run("run-docker-tests", timeout=1800)
+        self.assertEqual(status, 0, msg="run-docker-tests failed:\n%s" % output[-2000:])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_esrt.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_esrt.py
@@ -1,0 +1,35 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraEsrtTest(OERuntimeTestCase):
+    """ESRT present and populated; prerequisite gate for capsule/swupdate tests."""
+
+    def test_esrt_present(self):
+        # efi=runtime in KERNEL_ARGS means /sys/firmware/efi must exist; edk2-nvidia FMP populates ESRT
+        status, _ = self.target.run("test -d /sys/firmware/efi")
+        self.assertEqual(status, 0, msg="EFI sysfs absent; system must boot via edk2-nvidia")
+
+        status, _ = self.target.run("test -d /sys/firmware/efi/esrt")
+        self.assertEqual(status, 0, msg="ESRT sysfs dir absent; edk2-nvidia FMP should expose it")
+
+        _, entry = self.target.run(
+            "ls -d /sys/firmware/efi/esrt/entries/*/ 2>/dev/null | head -n1")
+        entry = entry.strip()
+        self.assertTrue(entry, msg="ESRT entries/ empty; FMP firmware should populate at least one entry")
+
+        status, fw_class = self.target.run("cat %sfw_class" % entry)
+        self.assertEqual(status, 0, msg="ESRT entry has no fw_class: %s" % fw_class)
+        self.assertRegex(
+            fw_class.strip(),
+            r"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            msg="ESRT fw_class is not a GUID: %s" % fw_class)
+
+        status, fw_version = self.target.run("cat %sfw_version" % entry)
+        self.assertEqual(status, 0, msg="ESRT entry has no fw_version: %s" % fw_version)
+        self.assertRegex(fw_version.strip(), r"^\d+$",
+                         msg="ESRT fw_version is not a decimal integer: %s" % fw_version)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_gstreamer.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_gstreamer.py
@@ -1,0 +1,50 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OERequirePackage
+
+class TegraGstreamerTest(OERuntimeTestCase):
+    """NVJPEG and NVDEC/NVENC pipelines; codecs to fakesink, canned scripts to nv3dsink."""
+
+    X = "DISPLAY=:0 XAUTHORITY=/root/.Xauthority"
+
+    def _element(self, name):
+        # gst-inspect <element> exits 255 when the element is missing, which OESSHTarget
+        # cannot tell from an ssh failure; assert against the plugin listing instead
+        status, _ = self.target.run("gst-inspect-1.0 2>/dev/null | grep -qw %s" % name)
+        self.assertEqual(status, 0, msg="gstreamer element %s not registered; plugin packaging gap" % name)
+
+    def _pipeline(self, desc):
+        status, output = self.target.run("gst-launch-1.0 " + desc, timeout=120)
+        self.assertEqual(status, 0, msg="pipeline failed:\n%s\n%s" % (desc, output[-2000:]))
+        self.assertIn("Got EOS", output,
+                      msg="pipeline produced no EOS (no frames flowed):\n%s" % output[-2000:])
+
+    def test_nvjpeg(self):
+        self._element("nvjpegenc")
+        self._element("nvjpegdec")
+        self._pipeline("videotestsrc num-buffers=10 ! 'video/x-raw,width=640,height=480,format=I420' "
+                       "! nvjpegenc ! nvjpegdec ! fakesink")
+
+    def test_h264_codec(self):
+        self._element("nvv4l2decoder")
+        if self.target.run("gst-inspect-1.0 nvvideo4linux2 2>/dev/null | grep -q nvv4l2h264enc")[0] != 0:
+            self.skipTest("no NVENC encoder on this SKU")
+        self._pipeline("videotestsrc num-buffers=30 ! 'video/x-raw,width=640,height=480' "
+                       "! nvvidconv ! 'video/x-raw(memory:NVMM)' ! nvv4l2h264enc ! h264parse "
+                       "! nvv4l2decoder ! fakesink")
+
+    @OERequirePackage(["gstreamer-tests"])
+    def test_display_pipelines(self):
+        # sinteltest renders through nv3dsink, nvjpegtest through xvimagesink, both on Xorg :0;
+        # the egl/weston images run no X server, so skip there rather than force a missing :0
+        if self.target.run("pgrep -x Xorg")[0] != 0:
+            self.skipTest("no X server; the nv3dsink display pipelines need Xorg :0")
+        for script in ("nvjpegtest", "sinteltest"):
+            status, output = self.target.run("%s %s" % (self.X, script), timeout=240)
+            self.assertEqual(status, 0, msg="%s failed:\n%s" % (script, output[-2000:]))
+            self.assertNotIn("ERROR", output, msg="%s pipeline error:\n%s" % (script, output[-2000:]))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_identity.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_identity.py
@@ -1,0 +1,49 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import os
+import re
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraIdentityTest(OERuntimeTestCase):
+    """kernel version and devicetree identity checks."""
+
+    def test_kernel_version(self):
+        status, output = self.target.run("uname -r")
+        self.assertEqual(status, 0, msg="uname failed: %s" % output)
+        ver = output.strip()
+        # require a suffix (e.g. -l4t-r36.5.0-1021.21 or -yocto-standard);
+        # a bare x.y.z string means the kernel was not built by this BSP
+        self.assertRegex(ver, r"^\d+\.\d+\.\d+.+",
+                         msg="unexpected kernel version format: %s" % ver)
+        self.assertIn("TEGRA_KERNEL_MIN", os.environ,
+                      msg="TEGRA_KERNEL_MIN not set: misconfigured harness (source jetpack-*.env)")
+        floor = os.environ["TEGRA_KERNEL_MIN"].strip()
+        m = re.match(r"(\d+)\.(\d+)", ver)
+        self.assertIsNotNone(m, msg="unparseable kernel version: %s" % ver)
+        got = (int(m.group(1)), int(m.group(2)))
+        want = tuple(int(x) for x in floor.split(".")[:2])
+        self.assertGreaterEqual(got, want,
+                                msg="kernel %s below floor %s" % (ver, floor))
+
+    def test_devicetree_compatible(self):
+        # the node is always present on a booted Tegra, so a read failure is a
+        # transport error, not a reason to skip
+        status, output = self.target.run(
+            "tr '\\000' '\\n' < /sys/firmware/devicetree/base/compatible")
+        self.assertEqual(status, 0, msg="cannot read devicetree compatible: %s" % output)
+        lines = [l.strip() for l in output.splitlines() if l.strip()]
+        self.assertTrue(lines, msg="empty devicetree compatible node")
+        self.assertRegex(lines[0], r"^(nvidia|oe4t),[a-z0-9]",
+                         msg="unexpected board compatible: %s" % lines[0])
+
+    def test_devicetree_model(self):
+        status, output = self.target.run(
+            "tr -d '\\000' < /sys/firmware/devicetree/base/model")
+        self.assertEqual(status, 0, msg="cannot read devicetree model: %s" % output)
+        self.assertIn("NVIDIA Jetson", output,
+                      msg="unexpected board model: %s" % output)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_kmodule.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_kmodule.py
@@ -1,0 +1,83 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import time
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraKernelModuleTest(OERuntimeTestCase):
+    """Unload and reload the ina3221 hwmon module."""
+
+    module = "ina3221"
+    HWMON_POLL_TRIES = 5
+
+    def _ina3221_dev(self):
+        # the power sensor's i2c bus/address differs per carrier (p3768 vs p3834); find it by binding
+        _, dev = self.target.run("ls -d /sys/bus/i2c/drivers/ina3221/*-* 2>/dev/null | head -n 1")
+        return dev.strip()
+
+    def _require_ina3221_bound(self):
+        # an ina3221 node in the devicetree but no bound i2c device is a probe failure (must fail);
+        # no node at all is genuine absence on this SKU (skip)
+        i2c_dev = self._ina3221_dev()
+        if i2c_dev:
+            return i2c_dev
+        _, in_dt = self.target.run(
+            "grep -ral ina3221 /sys/firmware/devicetree/base 2>/dev/null | head -n 1")
+        self.assertFalse(in_dt.strip(),
+                         msg="ina3221 in the devicetree but no bound i2c device; driver probe failed")
+        self.skipTest("ina3221 absent from the devicetree on this SKU (no power sensor)")
+
+    def test_unload_reload(self):
+        status, fname = self.target.run("modinfo -F filename %s" % self.module)
+        if status != 0:
+            self.fail("module %s not found by modinfo (image/packaging gap)" % self.module)
+        if "builtin" in fname.strip().lower():
+            self.skipTest("module %s is built-in, not unloadable" % self.module)
+
+        status, output = self.target.run("modprobe %s" % self.module)
+        self.assertEqual(status, 0, msg="initial load failed: %s" % output)
+
+        # ina3221 is DT-bound so refcnt >= 1 at boot; unbind before modprobe -r.
+        i2c_dev = self._require_ina3221_bound()
+
+        devname = i2c_dev.split("/")[-1]
+        status, out = self.target.run(
+            "echo '%s' > /sys/bus/i2c/drivers/%s/unbind" % (devname, self.module))
+        self.assertEqual(status, 0,
+                         msg="sysfs unbind of %s failed (needed before modprobe -r): %s"
+                         % (devname, out))
+
+        status, output = self.target.run("modprobe -r %s" % self.module)
+        self.assertEqual(status, 0, msg="unload failed: %s" % output)
+
+        status, output = self.target.run("modprobe %s" % self.module)
+        self.assertEqual(status, 0, msg="reload failed: %s" % output)
+
+        status, output = self.target.run("lsmod | grep -w %s" % self.module)
+        self.assertEqual(status, 0, msg="module absent after reload: %s" % output)
+
+        status, refcnt = self.target.run(
+            "awk '$1==\"%s\"{print $3}' /proc/modules" % self.module)
+        self.assertEqual(status, 0, msg=refcnt)
+        self.assertRegex(refcnt.strip(), r"^\d+$", msg="bad refcnt: %s" % refcnt)
+
+    def test_hwmon_readable(self):
+        i2c_dev = self._require_ina3221_bound()
+
+        status, _ = self.target.run("test -L %s/driver" % i2c_dev)
+        self.assertEqual(status, 0,
+                         msg="ina3221 driver not bound: %s/driver missing" % i2c_dev)
+
+        # the hwmon channel can re-register asynchronously, so poll briefly
+        voltage = ""
+        for _ in range(self.HWMON_POLL_TRIES):
+            _, voltage = self.target.run("cat %s/hwmon/hwmon*/in1_input 2>/dev/null" % i2c_dev)
+            if voltage.strip().isdigit():
+                break
+            time.sleep(1)
+        self.assertRegex(voltage.strip(), r"^\d+$",
+                         msg="ina3221 in1_input not a live reading: %r" % voltage)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_mmapi.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_mmapi.py
@@ -1,0 +1,35 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OERequirePackage
+
+class TegraMmapiTest(OERuntimeTestCase):
+    """MMAPI codec, JPEG, and convert samples via run-mmapi-tests."""
+
+    SAMPLES = ("video_decode video_dec_cuda jpeg_decode jpeg_encode video_convert "
+               "decode_sample transform_sample")
+    SAMPLES_ENCODE = "video_encode video_cuda_enc encode_sample"
+
+    def _run(self, samples):
+        status, output = self.target.run(
+            "DISPLAY=:0 XAUTHORITY=/root/.Xauthority run-mmapi-tests %s" % samples,
+            timeout=900)
+        self.assertEqual(status, 0, msg="mmapi samples failed:\n%s" % output[-3000:])
+        self.assertRegex(output, r"Tests passed:\s+[1-9]",
+                         msg="no mmapi sample passed:\n%s" % output[-3000:])
+
+    @OERequirePackage(["tegra-mmapi-tests"])
+    def test_mmapi_samples(self):
+        self._run(self.SAMPLES)
+
+    @OERequirePackage(["tegra-mmapi-tests"])
+    def test_mmapi_encode(self):
+        # gate on the encoder device node, the same check run-mmapi-tests uses for its encode
+        # subtests; the gst element can register without the node and would false-fail the run
+        if self.target.run("test -c /dev/v4l2-nvenc")[0] != 0:
+            self.skipTest("no NVENC encoder on this SKU")
+        self._run(self.SAMPLES_ENCODE)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_network.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_network.py
@@ -1,0 +1,26 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.core.decorator.depends import OETestDepends
+
+class TegraNetworkTest(OERuntimeTestCase):
+    """Physical NIC present with a live carrier."""
+
+    def test_nic_present(self):
+        # virtual ifaces (lo, bridges) have no device symlink; judge by output not status
+        _, output = self.target.run(
+            "for n in /sys/class/net/*; do [ -e \"$n/device\" ] && basename \"$n\"; done")
+        self.assertTrue(output.strip(),
+                        msg="no physical network interface bound (NIC driver not loaded)")
+
+    @OETestDepends(['tegra_network.TegraNetworkTest.test_nic_present'])
+    def test_carrier(self):
+        # read carrier only for physical ifaces; lo and bridges/veth always report 1
+        _, out = self.target.run(
+            "for n in /sys/class/net/*; do [ -e \"$n/device\" ] && cat \"$n/carrier\" 2>/dev/null; done")
+        self.assertIn("1", out.split(),
+                      msg="no physical NIC reports a live carrier (no cable attached): %s" % out)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_nvbootctrl.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_nvbootctrl.py
@@ -1,0 +1,23 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import re
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraNvbootctrlTest(OERuntimeTestCase):
+    """nvbootctrl reports a valid A/B bootloader slot layout."""
+
+    def test_dump_slots(self):
+        status, output = self.target.run("nvbootctrl dump-slots-info")
+        self.assertEqual(status, 0, msg=output)
+        self.assertRegex(output, r"(?mi)^\s*Active bootloader slot:\s*[AB]\b",
+                         msg="no active A/B slot reported:\n%s" % output)
+        self.assertRegex(output, r"(?mi)^\s*Capsule update status:\s*\d+",
+                         msg="no capsule update status reported:\n%s" % output)
+        slots = re.search(r"(?mi)^\s*num_slots:\s*(\d+)", output)
+        self.assertTrue(slots and int(slots.group(1)) >= 2,
+                        msg="fewer than two bootloader slots (no A/B redundancy):\n%s" % output)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_nvpmodel.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_nvpmodel.py
@@ -1,0 +1,58 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import re
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OERequirePackage
+from oeqa.core.decorator.depends import OETestDepends
+
+class TegraNvpmodelTest(OERuntimeTestCase):
+    """query the active nvpmodel mode and verify super-mode support."""
+
+    @OERequirePackage(["tegra-nvpmodel"])
+    def test_nvpmodel_query(self):
+        status, output = self.target.run("nvpmodel -q")
+        self.assertEqual(status, 0, msg=output)
+        self.assertRegex(output, r"NV Power Mode:\s+\w[\w -]*",
+                         msg="no active power mode name: %s" % output)
+        m = re.search(r"(?m)^\s*(\d+)\s*$", output)
+        self.assertIsNotNone(m, msg="no numeric mode id: %s" % output)
+
+    @OERequirePackage(["tegra-nvpmodel"])
+    @OETestDepends(['tegra_versions.TegraVersionsTest.test_l4t_release'])
+    def test_nvpmodel_super_mode(self):
+        # MAXN_SUPER: absent on Thor; p3767 since R36.4.3; p3701-0000 since R39.2
+        _, compat = self.target.run(
+            "cat /sys/firmware/devicetree/base/compatible 2>/dev/null | tr '\\000' '\\n'")
+        if "tegra264" in compat:
+            self.skipTest("Thor (tegra264) has no MAXN_SUPER mode")
+        if "p3767-" not in compat and "p3701-0000" not in compat:
+            self.skipTest("MAXN_SUPER not defined for this module")
+        if "p3701-0000" in compat:
+            _, rel = self.target.run("cat /etc/nv_tegra_release 2>/dev/null")
+            m = re.search(r"\bR(\d+)\b", rel)
+            if not m or int(m.group(1)) < 39:
+                self.skipTest("AGX Orin 32GB has MAXN_SUPER only from R39 (release: %s)"
+                              % (rel.strip()[:30] or "unknown"))
+
+        status, conf = self.target.run("cat /etc/nvpmodel.conf")
+        self.assertEqual(status, 0, msg="nvpmodel config /etc/nvpmodel.conf absent")
+        self.assertRegex(conf, r"(?m)^<\s*POWER_MODEL\s+ID=\d+\s+NAME=MAXN_SUPER\s*>",
+                         msg="no MAXN_SUPER POWER_MODEL entry in /etc/nvpmodel.conf: %s" % conf[-400:])
+        # the super-mode id varies by board (e.g. 2 on p3767-0003, 0 on p3767-0000)
+        m = re.search(r"(?m)^<\s*POWER_MODEL\s+ID=(\d+)\s+NAME=MAXN_SUPER\s*>", conf)
+        super_id = int(m.group(1))
+        status, output = self.target.run("nvpmodel -m %d" % super_id)
+        self.assertEqual(status, 0,
+                         msg="nvpmodel -m %d (MAXN_SUPER) failed: %s" % (super_id, output))
+        try:
+            status, output = self.target.run("nvpmodel -q")
+            self.assertEqual(status, 0, msg="nvpmodel -q after super switch failed: %s" % output)
+            self.assertIn("MAXN_SUPER", output,
+                          msg="active mode after -m %d is not MAXN_SUPER: %s" % (super_id, output))
+        finally:
+            self.target.run("nvpmodel -m 0")  # restore default mode for later tests

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_opencv.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_opencv.py
@@ -1,0 +1,18 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OEHasPackage
+
+class TegraOpencvTest(OERuntimeTestCase):
+    """OpenCV is installed with its CUDA modules."""
+
+    @OEHasPackage(["libopencv-cudaarithm"])
+    def test_opencv_cuda(self):
+        # the cuda* modules exist only when opencv is built WITH CUDA, so their presence is the check
+        status, so_path = self.target.run("ls /usr/lib*/libopencv_cudaarithm.so* 2>/dev/null")
+        self.assertTrue(status == 0 and so_path.strip(),
+                        msg="opencv CUDA modules not installed (no libopencv_cudaarithm.so*)")

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_optee.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_optee.py
@@ -1,0 +1,29 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.core.target.ssh import OESSHTarget
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraOpteeTest(OERuntimeTestCase):
+    """OP-TEE device node present and xtest regression passes."""
+
+    def test_tee_device(self):
+        status, _ = self.target.run("test -c /dev/tee0 || test -c /dev/teepriv0")
+        self.assertEqual(status, 0,
+                         msg="no OP-TEE device node (/dev/tee0, /dev/teepriv0); TEE driver not loaded")
+
+    def test_xtest_regression(self):
+        # xtest floods the secure-world UART, desyncing a serial console; run over SSH
+        if not isinstance(self.target, OESSHTarget):
+            self.skipTest("xtest regression needs an SSH target; serial cannot reconnect")
+        self.assertEqual(self.target.run("command -v xtest")[0], 0,
+                         msg="xtest (optee-test) not installed; packaging gap")
+        self.assertEqual(self.target.run("pidof tee-supplicant")[0], 0,
+                         msg="tee-supplicant not running; OP-TEE stack is broken")
+        # xtest exit code is the pass/fail signal; redirect its console flood to a file
+        status, _ = self.target.run("xtest 1001 >/tmp/xtest.1001.log 2>&1")
+        _, output = self.target.run("tail -c 2000 /tmp/xtest.1001.log")
+        self.assertEqual(status, 0, msg="xtest 1001 failed:\n%s" % output)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_overlay.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_overlay.py
@@ -1,0 +1,25 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraDevicetreeOverlayTest(OERuntimeTestCase):
+    """oe4t overlay applied; root compatible starts with oe4t,"""
+
+    def test_oe4t_compatible(self):
+        compatible = "/sys/firmware/devicetree/base/compatible"
+        status, output = self.target.run("tr '\\000' '\\n' < %s" % compatible)
+        self.assertEqual(status, 0,
+                         msg="cannot read devicetree compatible: %s" % output)
+        lines = [l.strip() for l in output.splitlines() if l.strip()]
+        self.assertTrue(lines, msg="empty devicetree compatible node")
+        # the oe4t dtb provider is mutually exclusive with the capsule/swupdate path,
+        # so skip rather than fail when it is not the active provider
+        if not any("oe4t," in l for l in lines):
+            self.skipTest("oe4t devicetree provider (tegrademo-devicetree) not in use; "
+                          "the overlay demo and the capsule/swupdate path cannot coexist")
+        self.assertRegex(lines[0], r"^oe4t,[a-z0-9]",
+                         msg="oe4t entry is not first compatible or malformed: %s" % lines[0])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_partition.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_partition.py
@@ -1,0 +1,21 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraPartitionTest(OERuntimeTestCase):
+    """by-partlabel entries present, confirming flash wrote the expected GPT."""
+
+    def test_partlabels(self):
+        status, output = self.target.run("ls /dev/disk/by-partlabel/")
+        self.assertEqual(status, 0,
+                         msg="ls /dev/disk/by-partlabel/ failed (rc=%d): %s" % (status, output))
+        self.assertTrue(output.strip(),
+                        msg="by-partlabel is empty; GPT was not laid down or udev did not enumerate it")
+        labels = output.split()
+        # APP is present in every L4T layout (AB and non-AB)
+        self.assertIn("APP", labels,
+                      msg="APP partlabel missing; named partitions: %s" % output)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_reboot.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_reboot.py
@@ -1,0 +1,47 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import os
+
+from oeqa.runtime.case import OERuntimeTestCase
+from tegra_reconnect import TegraReconnect
+from oeqa.core.target.ssh import OESSHTarget
+from oeqa.core.decorator.data import skipIfQemu
+from oeqa.core.decorator.depends import OETestDepends
+
+class TegraRollingRebootTest(TegraReconnect, OERuntimeTestCase):
+    """reboot survival; the rolling loop needs an SSH target to reconnect."""
+
+    REBOOT_MISSING = "reboot command not found; INIT_MANAGER=systemd must provide it"
+
+    @skipIfQemu()
+    def test_reboot_command_present(self):
+        status, output = self.target.run("command -v reboot")
+        self.assertEqual(status, 0, msg=self.REBOOT_MISSING)
+        self.assertTrue(output.strip(),
+                        msg="reboot command resolved to empty path: %s" % output)
+
+    @skipIfQemu()
+    @OETestDepends(['tegra_boottime.TegraBootTest.test_system_running'])
+    def test_rolling_reboot(self):
+        # serial cannot log back in once the board goes dark; the SSH target opens
+        # a fresh connection per command, so it survives the reboot drop
+        if not isinstance(self.target, OESSHTarget):
+            self.skipTest("rolling reboot needs an SSH target; serial cannot reconnect")
+        status, _ = self.target.run("command -v reboot")
+        self.assertEqual(status, 0, msg=self.REBOOT_MISSING)
+        # default 3 for routine gating; the CSV matrix run sets TEGRA_REBOOT_CYCLES higher
+        cycles = max(1, int(os.environ.get("TEGRA_REBOOT_CYCLES", "3")))
+
+        boot_id = self._boot_id()
+        self.assertTrue(boot_id, msg="could not read boot_id before reboot")
+        for cycle in range(1, cycles + 1):
+            self.target.run("sync; (sleep 1; reboot) >/dev/null 2>&1 &",
+                            timeout=10, ignore_ssh_fails=True)
+            boot_id = self._wait_for_new_boot(boot_id)
+            self.assertTrue(boot_id,
+                            msg="cycle %d/%d: no new boot_id within %ds; board did not "
+                                "reboot and return" % (cycle, cycles, self.BOOT_TIMEOUT))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_reconnect.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_reconnect.py
@@ -1,0 +1,32 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import time
+
+class TegraReconnect:
+    """boot_id helpers for cases that reboot or suspend the board. boot_id changes
+    on every boot, so it tells a real reboot from a slow link. SSH-only."""
+
+    BOOT_TIMEOUT = 300
+
+    def _boot_id(self):
+        for _ in range(6):
+            status, out = self.target.run("cat /proc/sys/kernel/random/boot_id",
+                                          timeout=30, ignore_ssh_fails=True)
+            if status == 0 and out.strip():
+                return out.strip()
+            time.sleep(5)
+        return ""
+
+    def _wait_for_new_boot(self, previous):
+        deadline = time.monotonic() + self.BOOT_TIMEOUT
+        while time.monotonic() < deadline:
+            time.sleep(5)
+            status, out = self.target.run("cat /proc/sys/kernel/random/boot_id",
+                                          timeout=15, ignore_ssh_fails=True)
+            if status == 0 and out.strip() and out.strip() != previous:
+                return out.strip()
+        return ""

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_samples.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_samples.py
@@ -1,0 +1,30 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraSamplesTest(OERuntimeTestCase):
+    """headless CUDA sample binaries from cuda-samples."""
+
+    def _run(self, path, name, expect=None):
+        status, _ = self.target.run("test -x %s" % path)
+        self.assertEqual(status, 0, msg="%s not installed; cuda-samples packaging gap" % name)
+        status, output = self.target.run(path)
+        self.assertEqual(status, 0, msg="%s failed:\n%s" % (name, output))
+        if expect:
+            self.assertRegex(output, expect,
+                             msg="%s: success not confirmed:\n%s" % (name, output))
+
+    def test_cuda_devicequery(self):
+        self._run("/usr/bin/cuda-samples/deviceQuery", "cuda deviceQuery",
+                  expect=r"Result = PASS")
+
+    def test_cuda_unified_memory(self):
+        self._run("/usr/bin/cuda-samples/UnifiedMemoryStreams", "cuda UnifiedMemoryStreams",
+                  expect=r"All Done!")
+
+    def test_cuda_vectoradd(self):
+        self._run("/usr/bin/cuda-samples/vectorAdd", "cuda vectorAdd", expect=r"Test PASSED")

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_storage.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_storage.py
@@ -1,0 +1,25 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraStorageTest(OERuntimeTestCase):
+    """rootfs writable and block-backed after flash+boot."""
+
+    def test_rootfs_writable(self):
+        status, output = self.target.run("findmnt -no OPTIONS /")
+        self.assertEqual(status, 0, msg="reading root mount failed: %s" % output)
+        self.assertRegex(output, r"(^|,)rw(,|$)", msg="rootfs not mounted rw: %s" % output)
+
+    def test_rootfs_on_block_device(self):
+        # findmnt resolves the real device behind the /dev/root placeholder
+        status, source = self.target.run("findmnt -no SOURCE /")
+        self.assertEqual(status, 0, msg="reading root source failed: %s" % source)
+        source = source.strip()
+        if not source.startswith("/dev/"):
+            self.fail("rootfs not block-backed after flash: %s" % source)
+        self.assertRegex(source, r"^/dev/(mmcblk|nvme|sd)",
+                         msg="rootfs not on expected storage: %s" % source)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_suspend.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_suspend.py
@@ -1,0 +1,105 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import time
+
+from oeqa.runtime.case import OERuntimeTestCase
+from tegra_reconnect import TegraReconnect
+from oeqa.core.target.ssh import OESSHTarget
+from oeqa.core.decorator.data import skipIfQemu
+from oeqa.core.decorator.depends import OETestDepends
+
+class TegraSc7AdvertisedTest(OERuntimeTestCase):
+    """SC7 (deep sleep) is advertised by the kernel; read-only, so it runs on any target."""
+
+    @skipIfQemu()
+    def test_sc7_state_advertised(self):
+        # mem = suspend-to-RAM (SC7) on Tegra
+        status, output = self.target.run("cat /sys/power/state")
+        self.assertEqual(status, 0,
+                         msg="/sys/power/state missing (kernel PM not built in?): %s" % output)
+        self.assertIn("mem", output.split(),
+                      msg="suspend-to-RAM (mem) not advertised in /sys/power/state "
+                          "(SC7 gap): %s" % output.strip())
+
+        # deep = SC7 mapping in mem_sleep
+        status, output = self.target.run("cat /sys/power/mem_sleep")
+        self.assertEqual(status, 0,
+                         msg="/sys/power/mem_sleep missing (SC7 not compiled in?): %s" % output)
+        self.assertRegex(output, r"\bdeep\b",
+                         msg="deep sleep (SC7) not offered by mem_sleep: %s" % output.strip())
+
+class TegraDeepSleepTest(TegraReconnect, OERuntimeTestCase):
+    """SC7 deep sleep RTC-wake cycle; needs an SSH target to reconnect."""
+
+    WAKE_AFTER = 30
+    RESUME_TIMEOUT = 120
+
+    def _wait_for_resume(self, success_before, started):
+        # the board is dark until the RTC fires, so a counter increment seen only
+        # after WAKE_AFTER elapsed proves this cycle, not a stray earlier suspend
+        deadline = started + self.WAKE_AFTER + self.RESUME_TIMEOUT
+        while time.monotonic() < deadline:
+            time.sleep(5)
+            status, out = self.target.run("cat /sys/power/suspend_stats/success",
+                                          timeout=15, ignore_ssh_fails=True)
+            if (status == 0 and out.strip().isdigit()
+                    and int(out.strip()) > success_before
+                    and time.monotonic() - started >= self.WAKE_AFTER):
+                return True
+        return False
+
+    @skipIfQemu()
+    @OETestDepends(['tegra_boottime.TegraBootTest.test_system_running'])
+    def test_sc7_rtcwake_cycle(self):
+        # the board wakes itself via the on-module RTC alarm (no external source);
+        # SSH only, since serial cannot reconnect after the board goes dark
+        if not isinstance(self.target, OESSHTarget):
+            self.skipTest("SC7 wake cycle needs an SSH target; serial cannot reconnect")
+        rtc = self.target.run(
+            "for r in /sys/class/rtc/*/wakealarm; do "
+            "[ -w \"$r\" ] && echo \"$r\" && break; done")[1].strip()
+        self.assertTrue(rtc,
+                        msg="no writable RTC wakealarm under /sys/class/rtc/*/wakealarm; "
+                            "tegra-rtc node absent or read-only (BSP regression)")
+        boot_before = self._boot_id()
+        self.assertTrue(boot_before, msg="could not read boot_id before suspend")
+
+        self.target.run("echo 0 > %s" % rtc)
+        self.assertEqual(self.target.run("echo +%d > %s" % (self.WAKE_AFTER, rtc))[0], 0,
+                         msg="could not arm RTC wakealarm at %s; PMC wakeup IRQ path broken" % rtc)
+        status, succ = self.target.run("cat /sys/power/suspend_stats/success")
+        self.assertEqual(status, 0,
+                         msg="/sys/power/suspend_stats/success missing "
+                             "(CONFIG_PM_SLEEP_STATS not enabled?): %s" % succ)
+        self.assertTrue(succ.strip().isdigit(),
+                        msg="suspend_stats/success not a digit: %r" % succ)
+        success_before = int(succ.strip())
+        # force SC7 (deep), not s2idle, so the cycle exercises real deep sleep
+        self.target.run("echo deep > /sys/power/mem_sleep")
+        _, ms = self.target.run("cat /sys/power/mem_sleep")
+        self.assertRegex(ms, r"\[deep\]",
+                         msg="mem_sleep did not select SC7 (deep); an s2idle cycle would "
+                             "false-pass this test: %s" % ms.strip())
+        started = time.monotonic()
+        self.target.run("(systemctl suspend || echo mem > /sys/power/state) &",
+                        timeout=5, ignore_ssh_fails=True)
+
+        self.assertTrue(self._wait_for_resume(success_before, started),
+                        msg="suspend counter did not advance after a full SC7 dwell; "
+                            "SC7 did not complete (check for a re-suspend loop or an "
+                            "enable_irq_wake failure)")
+        # an unchanged boot_id proves this was a suspend, not a reboot
+        self.assertEqual(self._boot_id(), boot_before,
+                         msg="boot_id changed across the cycle; board rebooted, not SC7")
+
+        # resume must leave the rootfs usable: a storage controller that does not
+        # come back returns EIO on every later read, which the boot_id check misses
+        self.target.run("sync; echo 3 > /proc/sys/vm/drop_caches", ignore_ssh_fails=True)
+        status, out = self.target.run("cat /bin/sh > /dev/null && echo ok")
+        self.assertEqual(status, 0,
+                         msg="rootfs read failed after SC7 resume; storage did not "
+                             "resume cleanly (e.g. NVMe EIO): %s" % out)

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_swupdate.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_swupdate.py
@@ -1,0 +1,91 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import os
+
+from oeqa.runtime.case import OERuntimeTestCase
+from tegra_reconnect import TegraReconnect
+from oeqa.runtime.decorator.package import OERequirePackage
+from oeqa.core.decorator.depends import OETestDepends
+from oeqa.core.target.ssh import OESSHTarget
+
+class TegraSwupdateTest(TegraReconnect, OERuntimeTestCase):
+    """swupdate A/B install and slot flip; needs a redundant-layout image and SSH."""
+
+    # the capsule (bootloader) update can add minutes to the first reboot
+    BOOT_TIMEOUT = 600
+    SWU_ON_DUT = "/tmp/tegra-swupdate-test.swu"
+
+    def _current_slot(self):
+        status, out = self.target.run("nvbootctrl get-current-slot")
+        self.assertEqual(status, 0, msg="nvbootctrl get-current-slot failed: %s" % out)
+        self.assertRegex(out.strip(), r"^[01]$", msg="unexpected current slot: %s" % out)
+        return out.strip()
+
+    def _dump_slots_info(self):
+        status, info = self.target.run("nvbootctrl dump-slots-info")
+        self.assertEqual(status, 0, msg="nvbootctrl dump-slots-info failed: %s" % info)
+        return info
+
+    @OERequirePackage(["swupdate"])
+    @OETestDepends(['tegra_esrt.TegraEsrtTest.test_esrt_present',
+                    'tegra_boottime.TegraBootTest.test_system_running'])
+    def test_ab_swupdate_cycle(self):
+        if not isinstance(self.target, OESSHTarget):
+            self.skipTest("A/B swupdate needs an SSH target; serial cannot reconnect")
+
+        status, _ = self.target.run("test -b /dev/disk/by-partlabel/APP_b")
+        self.assertEqual(status, 0,
+                         msg="no APP_b partition; image not built with USE_REDUNDANT_FLASH_LAYOUT")
+
+        # nvbootctrl MUST be present when both swupdate and redundant layout are present
+        status, out = self.target.run("command -v nvbootctrl")
+        self.assertEqual(status, 0,
+                         msg="nvbootctrl missing despite redundant layout; broken package deps: %s" % out)
+
+        swu = os.environ.get("SWUPDATE_SWU_HOST_PATH", "")
+        if swu and os.path.isfile(swu):
+            self.target.copyTo(swu, self.SWU_ON_DUT)
+        # artifact must exist on DUT; missing .swu on the swupdate image is a real failure
+        swu_present = self.target.run("test -f %s" % self.SWU_ON_DUT)[0]
+        self.assertEqual(swu_present, 0,
+                         msg=".swu not on DUT at %s; set SWUPDATE_SWU_HOST_PATH or pre-place it"
+                             % self.SWU_ON_DUT)
+
+        info = self._dump_slots_info()
+        self.assertRegex(info, r"(?mi)^\s*Capsule update status:\s*0\b",
+                         msg="capsule update status not 0 before update:\n%s" % info)
+
+        slot_before = self._current_slot()
+        boot_before = self._boot_id()
+        status, output = self.target.run("swupdate -i %s" % self.SWU_ON_DUT, timeout=600)
+        self.assertEqual(status, 0,
+                         msg="swupdate -i failed (%d):\n%s" % (status, output[-2000:]))
+
+        self.target.run("reboot", timeout=10, ignore_ssh_fails=True)
+        self.assertTrue(self._wait_for_new_boot(boot_before),
+                        msg="board did not reboot and return within %ds after swupdate"
+                            % self.BOOT_TIMEOUT)
+
+        info = self._dump_slots_info()
+        self.assertRegex(info, r"(?mi)^\s*Capsule update status:\s*1\b",
+                         msg="capsule update status not 1 after first reboot:\n%s" % info)
+
+        slot_after = self._current_slot()
+        self.assertNotEqual(slot_after, slot_before,
+                            msg="slot did not flip (before=%s after=%s)"
+                                % (slot_before, slot_after))
+
+        # second reboot confirms the flipped slot is sticky
+        boot_after = self._boot_id()
+        self.target.run("reboot", timeout=10, ignore_ssh_fails=True)
+        self.assertTrue(self._wait_for_new_boot(boot_after),
+                        msg="board did not return within %ds on second reboot"
+                            % self.BOOT_TIMEOUT)
+        slot_final = self._current_slot()
+        self.assertEqual(slot_final, slot_after,
+                         msg="slot reverted after second reboot (expected %s, got %s)"
+                             % (slot_after, slot_final))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_tensorrt.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_tensorrt.py
@@ -1,0 +1,19 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OEHasPackage
+
+class TegraTensorrtTest(OERuntimeTestCase):
+    """TensorRT sample engines via run-tensorrt-tests."""
+
+    @OEHasPackage(["tensorrt-tests"])
+    def test_tensorrt(self):
+        status, output = self.target.run("run-tensorrt-tests", timeout=900)
+        self.assertEqual(status, 0,
+                         msg="run-tensorrt-tests reported failures:\n%s" % output)
+        self.assertRegex(output, r"Tests passed:\s+[1-9]",
+                         msg="no tensorrt sample passed (all skipped?):\n%s" % output[-2000:])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_thermal.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_thermal.py
@@ -1,0 +1,39 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraThermalTest(OERuntimeTestCase):
+    """thermal zones reporting sane temps; broken BPMP path shows as zeros or empty."""
+
+    MIN_SANE_ZONES = 4
+
+    def test_zones_report_sane_temp(self):
+        status, listing = self.target.run(
+            "ls /sys/class/thermal/thermal_zone*/temp 2>/dev/null")
+        self.assertTrue(status == 0 and listing.strip(),
+                        msg="no thermal zones under /sys/class/thermal/ (BPMP driver failure)")
+        sane, zero_stuck, readings = [], [], []
+        for path in listing.split():
+            _, val = self.target.run("cat %s 2>/dev/null" % path)
+            val = val.strip()
+            readings.append("%s=%s" % (path, val))
+            try:
+                milli = int(val)
+            except ValueError:
+                # a disabled zone (tj-thermal on p3767/p3768) reads empty; skip it
+                continue
+            if milli == 0:
+                zero_stuck.append(path)
+                continue
+            if -20000 <= milli <= 150000:
+                sane.append(path)
+        self.assertEqual(zero_stuck, [],
+                         msg="thermal zones stuck at 0 (BPMP IPC error): %s" % zero_stuck)
+        # several zones reading sane temps proves the BPMP thermal path is healthy
+        self.assertGreaterEqual(len(sane), self.MIN_SANE_ZONES,
+                                msg="fewer than %d sane thermal zones (BPMP thermal path suspect): %s"
+                                    % (self.MIN_SANE_ZONES, readings))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_usb.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_usb.py
@@ -1,0 +1,49 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraUsbTest(OERuntimeTestCase):
+    """USB root hub enumerated and a downstream device attached."""
+
+    READ_MB = 8
+
+    def test_host_controller(self):
+        status, _ = self.target.run("test -d /sys/bus/usb/devices")
+        self.assertEqual(status, 0, msg="no USB host support (/sys/bus/usb/devices absent)")
+        status, output = self.target.run("ls -d /sys/bus/usb/devices/usb* 2>/dev/null")
+        self.assertEqual(status, 0, msg="no USB root hub: %s" % output)
+        self.assertRegex(output, r"/usb\d", msg="no USB root hub enumerated: %s" % output)
+
+    def test_downstream_device(self):
+        # grep -v ':' drops interface entries (e.g. 1-0:1.0) present even with nothing plugged in
+        _, output = self.target.run(
+            "ls -d /sys/bus/usb/devices/*-* 2>/dev/null | grep -v ':'")
+        # an unoccupied port is a bench fact, not a defect; skip rather than fail
+        if not output.strip():
+            self.skipTest("no downstream USB device attached")
+        self.assertRegex(output, r"devices/\d+-\d", msg="malformed USB device path: %s" % output)
+
+    def test_mass_storage(self):
+        # a mass-storage interface (class 08) with no /dev/sd = the driver did not bind
+        _, ms = self.target.run(
+            "grep -l '^08$' /sys/bus/usb/devices/*/bInterfaceClass 2>/dev/null")
+        if not ms.strip():
+            self.skipTest("no USB mass-storage device attached")
+        _, blk = self.target.run(
+            "for b in /sys/block/sd*; do [ -e \"$b\" ] && "
+            "readlink -f \"$b\" | grep -q usb && basename \"$b\"; done")
+        blk = blk.split()
+        self.assertTrue(blk,
+                        msg="USB mass-storage device enumerated but no /dev/sd block device; "
+                            "usb-storage/uas driver did not bind (image driver gap)")
+        dev = "/dev/%s" % blk[0]
+        # non-destructive: read a few MB off the raw device to exercise the USB data path
+        status, output = self.target.run(
+            "dd if=%s of=/dev/null bs=1M count=%d 2>&1" % (dev, self.READ_MB))
+        self.assertEqual(status, 0, msg="USB read from %s failed: %s" % (dev, output))
+        self.assertRegex(output, r"%d\+0 records (in|out)" % self.READ_MB,
+                         msg="USB read moved fewer than %dMB from %s: %s" % (self.READ_MB, dev, output))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_versions.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_versions.py
@@ -1,0 +1,57 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+import os
+import re
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraVersionsTest(OERuntimeTestCase):
+    """Floor-check L4T and CUDA versions against env vars."""
+
+    # source conf/jetpack-<release>.env before oe-test so the TEGRA_* floors are set;
+    # an unset floor is a misconfigured harness and must fail, not silently pass
+
+    def _nv_tegra_release(self):
+        # absence is a packaging gap, not a skip
+        status, output = self.target.run("cat /etc/nv_tegra_release 2>/dev/null")
+        self.assertTrue(status == 0 and output.strip(),
+                        msg="/etc/nv_tegra_release absent (nv-tegra-release not installed)")
+        return output
+
+    def test_l4t_release(self):
+        output = self._nv_tegra_release()
+        m = re.search(r"R(\d+)\b.*?REVISION:\s*([\d.]+)", output)
+        self.assertIsNotNone(m, msg="unparseable L4T release: %s" % output)
+        want = (os.environ.get("TEGRA_L4T_MAJOR") or "").strip()
+        self.assertTrue(want, msg="TEGRA_L4T_MAJOR not set")
+        self.assertEqual(m.group(1), want,
+                         msg="L4T major %s != expected %s" % (m.group(1), want))
+
+    def test_l4t_revision(self):
+        output = self._nv_tegra_release()
+        m = re.search(r"REVISION:\s*([\d.]+)", output)
+        self.assertIsNotNone(m, msg="REVISION field absent in nv_tegra_release: %s" % output)
+        want = (os.environ.get("TEGRA_L4T_MINOR") or "").strip()
+        self.assertTrue(want, msg="TEGRA_L4T_MINOR not set")
+        self.assertEqual(m.group(1), want,
+                         msg="L4T revision %s != expected %s" % (m.group(1), want))
+
+    def test_cuda_version(self):
+        # no nvcc in the runtime image; read the version from the install dir
+        status, dirs = self.target.run("ls -d /usr/local/cuda-*/ 2>/dev/null")
+        self.assertTrue(status == 0 and dirs.strip(),
+                        msg="CUDA not installed: no /usr/local/cuda-* dir found "
+                            "(cuda-libraries packaging gap)")
+        # pick the highest cuda-X.Y dir here rather than relying on target sort/tail
+        vers = re.findall(r"/cuda-(\d+)\.(\d+)", dirs)
+        self.assertTrue(vers, msg="unparseable CUDA install dir: %s" % dirs)
+        got = max((int(a), int(b)) for a, b in vers)
+        floor = (os.environ.get("TEGRA_CUDA_MIN") or "").strip()
+        self.assertTrue(floor, msg="TEGRA_CUDA_MIN not set")
+        want = tuple(int(x) for x in floor.split(".")[:2])
+        self.assertGreaterEqual(got, want,
+                                msg="CUDA %d.%d below floor %s" % (got[0], got[1], floor))

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_vpi.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_vpi.py
@@ -1,0 +1,22 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraVpiTest(OERuntimeTestCase):
+    """VPI sample suite across the backends the SKU provides."""
+
+    def test_vpi_samples(self):
+        # the harness ships as run-vpi-tests plus a release-versioned symlink (run-vpi4-tests on
+        # R39); glob for it and skip cleanly rather than gate on a versioned package
+        _, harness = self.target.run("ls /usr/bin/run-vpi*-tests 2>/dev/null | head -n 1")
+        harness = harness.strip()
+        if not harness:
+            self.skipTest("no run-vpi*-tests harness installed (vpi-tests package absent)")
+        status, output = self.target.run(harness, timeout=1800)
+        self.assertEqual(status, 0, msg="%s reported failures:\n%s" % (harness, output[-2000:]))
+        self.assertRegex(output, r"Tests passed:\s+[1-9]",
+                         msg="no VPI sample passed:\n%s" % output[-2000:])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_vulkan.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_vulkan.py
@@ -1,0 +1,23 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.runtime.decorator.package import OERequirePackage
+
+class TegraVulkanTest(OERuntimeTestCase):
+    """vulkaninfo enumerates the Tegra GPU through the NVIDIA proprietary driver (headless)."""
+
+    @OERequirePackage(["vulkan-tools"])
+    @OERequirePackage(["tegra-libraries-vulkan"])
+    def test_vulkaninfo(self):
+        status, output = self.target.run("vulkaninfo")
+        self.assertEqual(status, 0, msg="vulkaninfo failed to run:\n%s" % output[-2000:])
+        # require the NVIDIA proprietary driver, not the gfxstream/virtio fallback ICDs
+        self.assertIn("DRIVER_ID_NVIDIA_PROPRIETARY", output,
+                      msg="Vulkan did not load the NVIDIA driver (software/virtio fallback):\n%s"
+                          % output[-2000:])
+        self.assertRegex(output, r"deviceType\s*=\s*PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                         msg="Vulkan device is not the integrated Tegra GPU:\n%s" % output[-2000:])

--- a/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_watchdog.py
+++ b/layers/meta-tegrademo/lib/oeqa/runtime/cases/tegra_watchdog.py
@@ -1,0 +1,18 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+from oeqa.runtime.case import OERuntimeTestCase
+
+class TegraWatchdogTest(OERuntimeTestCase):
+    """watchdog device registered; presence only, not triggered."""
+
+    def test_watchdog_present(self):
+        # tegra-wdt is mandatory; absence is a fault
+        status, _ = self.target.run("test -c /dev/watchdog || test -c /dev/watchdog0")
+        self.assertEqual(status, 0, msg="no /dev/watchdog device node")
+        status, output = self.target.run("ls /sys/class/watchdog/ 2>/dev/null")
+        self.assertEqual(status, 0, msg="no /sys/class/watchdog/ directory (output: %r)" % output)
+        self.assertRegex(output, r"watchdog\d+", msg="no registered watchdog in sysfs: %s" % output)

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-common.inc
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-common.inc
@@ -6,6 +6,15 @@ inherit core-image
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-base packagegroup-demo-basetests"
 CORE_IMAGE_BASE_INSTALL += "${@'packagegroup-demo-systemd' if d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd' else ''}"
+CORE_IMAGE_BASE_INSTALL += "nv-tegra-release"
 TOOLCHAIN_HOST_TASK += "nativesdk-packagegroup-cuda-sdk-host"
+
+# baseline suite; images add their extras via TEST_SUITES:append (not the "auto" set)
+TEST_SUITES = "ping ssh date df oe_syslog \
+               tegra_identity tegra_versions tegra_storage tegra_thermal \
+               tegra_boottime tegra_console tegra_usb tegra_network \
+               tegra_watchdog tegra_esrt tegra_partition tegra_nvpmodel \
+               tegra_kmodule tegra_nvbootctrl tegra_overlay tegra_optee \
+               tegra_samples tegra_display tegra_reboot tegra_suspend"
 
 inherit nopackages

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-egl.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-egl.bb
@@ -9,3 +9,5 @@ inherit features_check
 REQUIRED_DISTRO_FEATURES = "opengl"
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-egltests"
+
+TEST_SUITES:append = " tegra_gstreamer tegra_camera"

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-full.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-full.bb
@@ -11,4 +11,10 @@ REQUIRED_DISTRO_FEATURES = "x11 opengl"
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-x11tests"
 CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'packagegroup-demo-vulkantests', '', d)}"
-CORE_IMAGE_BASE_INSTALL += "cuda-libraries tegra-mmapi-tests vpi4-tests tensorrt-tests"
+CORE_IMAGE_BASE_INSTALL += "cuda-libraries tegra-mmapi-tests tensorrt-tests vpi-tests"
+
+# tegra_docker is added by the meta-virtualization bbappend, which ships docker
+TEST_SUITES:append = " tegra_gstreamer tegra_vulkan tegra_vpi tegra_mmapi \
+                       tegra_camera tegra_opencv tegra_tensorrt \
+                       tegra_deepstream \
+                       tegra_capsule"

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-sato.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-sato.bb
@@ -8,3 +8,5 @@ IMAGE_FEATURES += "splash x11-base x11-sato hwcodecs"
 
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-x11tests"
 CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'packagegroup-demo-vulkantests', '', d)}"
+
+TEST_SUITES:append = " tegra_gstreamer tegra_vulkan tegra_camera"

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-weston.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-weston.bb
@@ -17,3 +17,5 @@ CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'west
 CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'packagegroup-demo-vulkantests', '', d)}"
 CORE_IMAGE_BASE_INSTALL += "${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio-server pulseaudio-misc', '', d)}"
 SYSTEMD_DEFAULT_TARGET = "graphical.target"
+
+TEST_SUITES:append = " tegra_gstreamer tegra_vulkan tegra_camera"


### PR DESCRIPTION
Re-targets https://github.com/OE4T/tegra-demo-distro/pull/389 to master (auto-closed when the wip-l4t-r39.2.0 branch was removed).

Adds oeqa tests for the Tegra demo images similar to what the L4T Releases `.csv` was testing.

To enable you require one of two conf fragments in your build's local.conf. require conf/tegra-testexport.conf builds a self-contained bundle (bitbake <image> -c testexport) that oe-test runs later on another host.

The cases are plain OERuntimeTestCases, and the version checks read a floor from conf/jetpack-{6.2,7.2}.env (so should be compatible for scarthgap backport as well).

I've tested this on both `jetson-orin-nano-devkit-nvme` and `jetson-agx-thor-devkit`. To try it `require conf/tegra-testexport.conf`, bitbake <image> -c testexport, then run the bundle with oe-test (--target-type serial for a console-only DUT, or simpleremote over SSH).

```
2026-06-29 13:31:56,871 - runtime - INFO - SUMMARY:
2026-06-29 13:31:56,871 - runtime - INFO - runtime () - Ran 59 tests in 375.154s
2026-06-29 13:31:56,871 - runtime - INFO - runtime - OK - All required tests passed (successes=49, skipped=10, failures=0, errors=0)
```

I've used [this repo](https://github.com/maximdeclercq/oeqa-reporter) I made for creating these reporting templates from oeqa-runner.

https://drive.google.com/drive/u/0/folders/1oRQiTwie_Ty89-CausRJ3EqM7wG5hUaj