### PR TITLE
connman-conf: avoid interface conflicts with systemd-networkd on tegr…

### DIFF
--- a/layers/meta-tegrademo/recipes-connectivity/connman/connman-conf.bbappend
+++ b/layers/meta-tegrademo/recipes-connectivity/connman/connman-conf.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:tegra264 = " file://main.conf.tegra264"
+
+do_install:append:tegra264() {
+    install -d ${D}${sysconfdir}/connman
+    install -m 0644 ${UNPACKDIR}/main.conf.tegra264 ${D}${sysconfdir}/connman/main.conf
+}

--- a/layers/meta-tegrademo/recipes-connectivity/connman/connman-conf/main.conf.tegra264
+++ b/layers/meta-tegrademo/recipes-connectivity/connman/connman-conf/main.conf.tegra264
@@ -1,0 +1,2 @@
+[General]
+NetworkInterfaceBlacklist = mgbe,usb,rndis,docker


### PR DESCRIPTION
* connman was attempting to manage network interfaces that are owned by
other subsystems (mgbe ethernet handled by systemd-networkd, USB RNDIS
gadget, and the docker bridge), causing conflicts. Add a tegra264-specific
main.conf that blacklists these interfaces so connman leaves them to their
respective managers.
    
* Blacklisted interface prefixes: mgbe, usb, rndis, docker.