### PR TITLE
Addition of tegrademo-extended / demo-image-reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = repos/openembedded-core
 	url = https://github.com/openembedded/openembedded-core.git
 	branch = master
+[submodule "repos/meta-swupdate"]
+	path = repos/meta-swupdate
+	url = https://github.com/sbabic/meta-swupdate.git
+	branch = master

--- a/layers/meta-gnome
+++ b/layers/meta-gnome
@@ -1,0 +1,1 @@
+../repos/meta-openembedded/meta-gnome

--- a/layers/meta-swupdate
+++ b/layers/meta-swupdate
@@ -1,0 +1,1 @@
+../repos/meta-swupdate

--- a/layers/meta-tegra-support/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/layers/meta-tegra-support/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " opus"

--- a/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
+++ b/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
@@ -19,6 +19,12 @@ REQUIRED_TD_BBLAYERS_CONF_VERSION = "${DISTRO}-7"
 
 LOCALCONF_VERSION = "2"
 
+INHERIT += "tegra-support-sanity"
+ESDK_CLASS_INHERIT_DISABLE:append = " tegra-support-sanity"
+
+BB_SIGNATURE_HANDLER ?= "OEEquivHash"
+BB_HASHSERVE ??= "auto"
+
 TD_DEFAULT_DISTRO_FEATURES = "pam virtualization"
 DISTRO_FEATURES ?= "${TD_DEFAULT_DISTRO_FEATURES}"
 
@@ -47,5 +53,6 @@ USE_REDUNDANT_FLASH_LAYOUT_DEFAULT ?= "1"
 
 # for docker-registry-config
 DOCKER_OCI_RUNTIMES ?= '{"nvidia":{"args":[],"path":"nvidia-container-runtime"}}'
+DOCKER_DEFAULT_RUNTIME ?= "nvidia"
 
 require ${@'dynamic-layers/meta-swupdate/conf/distro/include/tegra-swupdate.inc' if 'swupdate' in d.getVar('BBFILE_COLLECTIONS').split() else ''}

--- a/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
+++ b/layers/meta-tegrademo/conf/distro/include/tegrademo.inc
@@ -47,7 +47,7 @@ SANITY_TESTED_DISTROS ?= " \
 # Most NVIDIA-supplied services expect systemd
 INIT_MANAGER = "systemd"
 
-LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264"
+LICENSE_FLAGS_ACCEPTED += "commercial_faad2 commercial_x264 commercial_gstreamer1.0-libav commercial_ffmpeg"
 
 USE_REDUNDANT_FLASH_LAYOUT_DEFAULT ?= "1"
 

--- a/layers/meta-tegrademo/conf/distro/tegrademo-extended.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo-extended.conf
@@ -1,0 +1,40 @@
+# Tegra Demo Extended Test Distro configuration
+
+# Override some defaults for tegrademo distro for the extended one:
+
+# Use the vendor-provided kernel in -rt variant for testing
+TEGRA_DEFAULT_KERNEL ?= "linux-noble-nvidia-tegra-rt"
+
+require conf/distro/include/tegrademo.inc
+
+# Use full UEFI (hard-assignment to override tegra-swupdate.inc)
+TEGRA_MINIMAL_BOOT = "0"
+
+DISTRO = "tegrademo-extended"
+DISTRO_NAME = "OE4Tegra Extended Test Distro"
+
+DISTRO_FEATURES += " wayland opengl wifi x11 vulkan bluetooth overlayfs pulseaudio"
+
+OVERLAYFS_MOUNT_POINT[data] = "/data"
+# data.mount is only installed in images that include data-partition; suppress
+# the global QA check that would otherwise fire for every image in the build.
+OVERLAYFS_QA_SKIP[data] = "mount-configured"
+
+# Replace busybox with full GNU coreutils
+VIRTUAL-RUNTIME_base-utils = "coreutils"
+VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"
+VIRTUAL-RUNTIME_base-utils-syslog = ""
+
+# Enable nmtui (curses-based WiFi/network config UI)
+PACKAGECONFIG:append:pn-networkmanager = " nmtui"
+
+# x11-sato uses NETWORK_MANAGER to select the network applet; default is connman-gnome
+NETWORK_MANAGER ?= "network-manager-applet"
+
+PREFERRED_RPROVIDER_libnss-mdns = "avahi-libnss-mdns"
+
+# OSC 3008 terminal shell integration — on unsupporting terminals this prints
+# raw escape sequences to the login prompt. Disable it.
+PACKAGECONFIG:remove:pn-systemd = "osc-context"
+
+PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"

--- a/layers/meta-tegrademo/conf/distro/tegrademo.conf
+++ b/layers/meta-tegrademo/conf/distro/tegrademo.conf
@@ -1,7 +1,1 @@
 require conf/distro/include/tegrademo.inc
-
-INHERIT += "tegra-support-sanity"
-ESDK_CLASS_INHERIT_DISABLE:append = " tegra-support-sanity"
-
-BB_SIGNATURE_HANDLER ?= "OEEquivHash"
-BB_HASHSERVE ??= "auto"

--- a/layers/meta-tegrademo/conf/templates/tegrademo-extended/bblayers.conf.sample
+++ b/layers/meta-tegrademo/conf/templates/tegrademo-extended/bblayers.conf.sample
@@ -1,0 +1,23 @@
+# Version of layers configuration, specific to
+# each defined distro in the repository.
+# Format: ${DISTRO}-<version>
+TD_BBLAYERS_CONF_VERSION = "tegrademo-extended-7"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ##OEROOT##/meta \
+  ##OEROOT##/meta-tegra \
+  ##OEROOT##/meta-oe \
+  ##OEROOT##/meta-python \
+  ##OEROOT##/meta-networking \
+  ##OEROOT##/meta-gnome \
+  ##OEROOT##/meta-filesystems \
+  ##OEROOT##/meta-virtualization \
+  ##OEROOT##/meta-swupdate \
+  ##OEROOT##/meta-tegra-community \
+  ##OEROOT##/meta-tegra-support \
+  ##OEROOT##/meta-demo-ci \
+  ##OEROOT##/meta-tegrademo \
+  "

--- a/layers/meta-tegrademo/conf/templates/tegrademo-extended/conf-notes.txt
+++ b/layers/meta-tegrademo/conf/templates/tegrademo-extended/conf-notes.txt
@@ -1,0 +1,6 @@
+### Shell environment set up for builds. ###
+
+You can now run 'bitbake <target>'
+Targets for building the Tegra reference image:
+    demo-image-reference - Wayland/Weston desktop with NetworkManager and comprehensive QA test tools
+    swupdate-image-tegra - SWUpdate OTA update image (requires USE_REDUNDANT_FLASH_LAYOUT=1)

--- a/layers/meta-tegrademo/conf/templates/tegrademo-extended/local.conf.sample
+++ b/layers/meta-tegrademo/conf/templates/tegrademo-extended/local.conf.sample
@@ -1,0 +1,98 @@
+# This file is your local configuration file and is where all local user settings
+# are placed. The comments in this file give some guide to the options a new user
+# to the system might want to change but pretty much any configuration option can
+# be set in this file.
+
+#
+# Machine Selection
+#
+# You need to select a specific machine to target the build with.
+# The following machines are avilable in the meta-tegra layer:
+#
+#MACHINE ?= "jetson-agx-orin-devkit"
+#MACHINE ?= "jetson-orin-nano-devkit"
+#@TD_SETUP_MACHINE@ - placeholder for automatic insertion by setup-env
+#
+# This sets the default machine to be qemux86-64 if no other machine is selected:
+MACHINE ??= "qemux86-64"
+
+#
+# Where to place downloads
+#
+#DL_DIR ?= "${TOPDIR}/downloads"
+
+#
+# Where to place shared-state files
+#
+#SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
+
+#
+# Where to place the build output
+#
+#TMPDIR = "${TOPDIR}/tmp"
+
+#
+# Default policy (distro) config
+#
+#@TD_SETUP_DISTRO@ - placeholder for automatic insertion by setup-env
+DISTRO ?= "tegrademo-extended"
+
+#
+# Package Management configuration
+#
+#PACKAGE_CLASSES ?= "package_rpm"
+
+#
+# SDK target architecture
+#
+SDKMACHINE ?= "x86_64"
+
+#
+# Extra image configuration defaults
+#
+EXTRA_IMAGE_FEATURES ?= "allow-empty-password empty-root-password allow-root-login serial-autologin-root"
+
+#
+# Additional image features
+#
+USER_CLASSES ?= "buildstats"
+
+#
+# Interactive shell configuration
+#
+PATCHRESOLVE = "noop"
+
+#
+# Disk Space Monitoring during the build
+#
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
+
+#
+# Hash Equivalence
+#
+#BB_HASHSERVE = "auto"
+#BB_SIGNATURE_HANDLER = "OEEquivHash"
+
+#
+# Memory Resident Bitbake
+#
+#BB_SERVER_TIMEOUT = "60"
+
+# CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
+# track the version of this file when it was generated. This can safely be ignored if
+# this doesn't mean anything to you.
+CONF_VERSION = "2"
+
+#
+# SWUpdate configuration
+#
+# Name of the core image to use as the SWUpdate payload.
+SWUPDATE_CORE_IMAGE_NAME = "demo-image-reference"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-bsp/uefi/tegra-espimage.bbappend
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-bsp/uefi/tegra-espimage.bbappend
@@ -1,0 +1,1 @@
+IMAGE_FSTYPES:append = " tar.gz"

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/demo-image-reference-swupdate.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/demo-image-reference-swupdate.bb
@@ -1,0 +1,1 @@
+require swupdate-image-tegra-common.inc

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/files/sw-description
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/files/sw-description
@@ -36,6 +36,7 @@ software =
 						name = "tegra-bootloader-capsule"
 						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
 					}
+					@@OPTIONAL_ESP_UPDATE@@
 				);
 				scripts: (
 					{
@@ -77,6 +78,7 @@ software =
 						name = "tegra-bootloader-capsule"
 						version = "@@TEGRA_SWUPDATE_BOOTLOADER_VERSION@@"
 					}
+					@@OPTIONAL_ESP_UPDATE@@
 				);
 				scripts: (
 					{

--- a/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra-common.inc
+++ b/layers/meta-tegrademo/dynamic-layers/meta-swupdate/recipes-demo/images/swupdate-image-tegra-common.inc
@@ -14,6 +14,31 @@ require dynamic-layers/meta-swupdate/recipes-support/swupdate/tegra-swupdate.inc
 
 ROOTFS_DEVICE_PATH ?= "/dev/disk/by-partlabel"
 
+# ESP (EFI System Partition) archive for non-minimal boot builds.
+# In non-minimal builds, BOOTAA64.efi (L4TLauncher) lives on the ESP and
+# must be kept in sync with the firmware via OTA.  In minimal-boot builds,
+# L4TLauncher is compiled into the UEFI image itself and the ESP file is
+# absent, so this entry must be omitted from both the .swu CPIO and the
+# sw-description to avoid swupdate errors.
+ESP_ARCHIVE = "${TEGRA_ESP_IMAGE}-${MACHINE}.tar.gz"
+
+def optional_esp_update(d):
+    if bb.utils.to_boolean(d.getVar('TEGRA_MINIMAL_BOOT')):
+        return ""
+    archive = d.getVar('ESP_ARCHIVE')
+    version = d.getVar('TEGRA_SWUPDATE_BOOTLOADER_VERSION')
+    return f""",
+    {{
+        filename = "{archive}";
+        type = "archive";
+        installed-directly = true;
+        path = "/boot/efi";
+        name = "tegra-bootloader-capsule";
+        version = "{version}";
+    }}"""
+
+OPTIONAL_ESP_UPDATE = "${@optional_esp_update(d)}"
+
 # By default, infer the image name from our recipe name. To create
 # a recipe for a swupdate based off an image, just create
 # '<imagename>-swupdate.bb' and have it include this .inc file
@@ -23,13 +48,16 @@ ROOTFS_FILENAME ?= "${SWUPDATE_CORE_IMAGE_NAME}-${MACHINE}.rootfs.tar.gz"
 
 # images to build before building swupdate image. For any non image depends, add to the do_swuimage[depends] instead.
 IMAGE_DEPENDS = "${SWUPDATE_CORE_IMAGE_NAME}"
+IMAGE_DEPENDS:append = "${@' tegra-espimage' if not bb.utils.to_boolean(d.getVar('TEGRA_MINIMAL_BOOT')) else ''}"
 
 # images and files that will be included in the .swu image
 SWUPDATE_IMAGES = "${ROOTFS_FILENAME} tegra-bl.cap tegra-swupdate-script.lua"
+SWUPDATE_IMAGES:append = "${@' ' + d.getVar('ESP_ARCHIVE') if not bb.utils.to_boolean(d.getVar('TEGRA_MINIMAL_BOOT')) else ''}"
 
 # All non-image related depends go here
 do_swuimage[depends] += "tegra-uefi-capsules:do_deploy"
 do_swuimage[depends] += "tegra-swupdate-script:do_deploy"
+do_swuimage[depends] += "${@'tegra-espimage:do_image_complete' if not bb.utils.to_boolean(d.getVar('TEGRA_MINIMAL_BOOT')) else ''}"
 
 # Add a link using the core image name.swu to the resulting swu image
 do_swuimage:append() {

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/containerd/containerd-data-conf/config.toml
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/containerd/containerd-data-conf/config.toml
@@ -1,0 +1,3 @@
+version = 4
+root = "/data/containerd"
+state = "/run/containerd"

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/containerd/containerd-data-conf/containerd-data-root.conf
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/containerd/containerd-data-conf/containerd-data-root.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=data.mount
+Wants=data.mount

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/containerd/containerd-data-conf_1.0.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/containerd/containerd-data-conf_1.0.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "Redirect containerd data root to /data/containerd (requires data-partition)"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://config.toml \
+    file://containerd-data-root.conf \
+"
+
+S = "${UNPACKDIR}"
+
+inherit systemd
+
+do_install() {
+    install -d ${D}${sysconfdir}/containerd
+    install -m 0644 ${S}/config.toml ${D}${sysconfdir}/containerd/
+
+    install -d ${D}${systemd_system_unitdir}/containerd.service.d
+    install -m 0644 ${S}/containerd-data-root.conf ${D}${systemd_system_unitdir}/containerd.service.d/
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/containerd/config.toml \
+    ${systemd_system_unitdir}/containerd.service.d/containerd-data-root.conf \
+"
+
+RDEPENDS:${PN} = "containerd data-partition"
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/docker/docker-data-conf/docker-data-root.conf
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/docker/docker-data-conf/docker-data-root.conf
@@ -1,0 +1,7 @@
+[Unit]
+After=data.mount
+Wants=data.mount
+
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock --data-root /data/docker

--- a/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/docker/docker-data-conf_1.0.bb
+++ b/layers/meta-tegrademo/dynamic-layers/meta-virtualization/recipes-containers/docker/docker-data-conf_1.0.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Redirect Docker data root to /data/docker (requires data-partition)"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://docker-data-root.conf"
+
+S = "${UNPACKDIR}"
+
+inherit systemd
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}/docker.service.d
+    install -m 0644 ${S}/docker-data-root.conf ${D}${systemd_system_unitdir}/docker.service.d/
+}
+
+FILES:${PN} = "${systemd_system_unitdir}/docker.service.d/docker-data-root.conf"
+
+RDEPENDS:${PN} = "docker data-partition"
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/layers/meta-tegrademo/recipes-connectivity/networkmanager-config/files/70-tegra-mgbe-unmanaged.conf
+++ b/layers/meta-tegrademo/recipes-connectivity/networkmanager-config/files/70-tegra-mgbe-unmanaged.conf
@@ -1,0 +1,8 @@
+# NetworkManager configuration for Tegra mgbe (Camera Eagle) ports.
+# These interfaces are already managed by systemd-networkd (see
+# systemd-networkd-config), so mark them unmanaged here to avoid NM
+# racing networkd to configure them and blocking
+# NetworkManager-wait-online.service on unpopulated CoE ports.
+
+[keyfile]
+unmanaged-devices=interface-name:mgbe*

--- a/layers/meta-tegrademo/recipes-connectivity/networkmanager-config/networkmanager-config_1.0.bb
+++ b/layers/meta-tegrademo/recipes-connectivity/networkmanager-config/networkmanager-config_1.0.bb
@@ -1,0 +1,16 @@
+SUMMARY = "NetworkManager configuration for Tegra platforms"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "(tegra264)"
+
+SRC_URI = "file://70-tegra-mgbe-unmanaged.conf"
+
+do_install() {
+    install -d ${D}${sysconfdir}/NetworkManager/conf.d
+    install -m 0644 ${UNPACKDIR}/70-tegra-mgbe-unmanaged.conf ${D}${sysconfdir}/NetworkManager/conf.d/
+}
+
+FILES:${PN} = "${sysconfdir}/NetworkManager/conf.d/70-tegra-mgbe-unmanaged.conf"
+
+RDEPENDS:${PN} = "networkmanager"

--- a/layers/meta-tegrademo/recipes-connectivity/systemd-networkd-config/files/70-tegra-mgbe.network
+++ b/layers/meta-tegrademo/recipes-connectivity/systemd-networkd-config/files/70-tegra-mgbe.network
@@ -1,0 +1,15 @@
+# systemd-networkd configuration for Tegra mgbe (Camera Eagle) ports.
+# Sets RequiredForOnline=no so that unpopulated CoE ports do not block
+# systemd-networkd-wait-online.service during boot. The mgbe interfaces
+# remain managed by networkd and will link up when a CoE cable is connected.
+# CoE-specific images that gate boot on a populated mgbe port should override
+# this with a drop-in setting RequiredForOnline=yes for that interface.
+
+[Match]
+Name=mgbe*
+
+[Link]
+RequiredForOnline=no
+
+[Network]
+DHCP=yes

--- a/layers/meta-tegrademo/recipes-connectivity/systemd-networkd-config/systemd-networkd-config_1.0.bb
+++ b/layers/meta-tegrademo/recipes-connectivity/systemd-networkd-config/systemd-networkd-config_1.0.bb
@@ -1,0 +1,16 @@
+SUMMARY = "systemd-networkd configuration for Tegra platforms"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "(tegra264)"
+
+SRC_URI = "file://70-tegra-mgbe.network"
+
+do_install() {
+    install -d ${D}${sysconfdir}/systemd/network
+    install -m 0644 ${UNPACKDIR}/70-tegra-mgbe.network ${D}${sysconfdir}/systemd/network/
+}
+
+FILES:${PN} = "${sysconfdir}/systemd/network/70-tegra-mgbe.network"
+
+RDEPENDS:${PN} = "systemd"

--- a/layers/meta-tegrademo/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-tegrademo/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,2 @@
+# repart is disabled upstream by default; enable it (requires openssl).
+PACKAGECONFIG:append = " repart openssl"

--- a/layers/meta-tegrademo/recipes-demo/data-partition/data-partition/10-data-overlays.conf
+++ b/layers/meta-tegrademo/recipes-demo/data-partition/data-partition/10-data-overlays.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=data-partition-overlays.service
+Wants=data-partition-overlays.service

--- a/layers/meta-tegrademo/recipes-demo/data-partition/data-partition/50-data.conf
+++ b/layers/meta-tegrademo/recipes-demo/data-partition/data-partition/50-data.conf
@@ -1,0 +1,5 @@
+[Partition]
+Type=linux-generic
+Label=data
+Format=ext4
+GrowFileSystem=yes

--- a/layers/meta-tegrademo/recipes-demo/data-partition/data-partition/data.mount
+++ b/layers/meta-tegrademo/recipes-demo/data-partition/data-partition/data.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=User data partition
+After=systemd-repart.service
+
+[Mount]
+What=LABEL=data
+Where=/data
+Type=ext4
+Options=defaults
+
+[Install]
+WantedBy=local-fs.target

--- a/layers/meta-tegrademo/recipes-demo/data-partition/data-partition_1.0.bb
+++ b/layers/meta-tegrademo/recipes-demo/data-partition/data-partition_1.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 inherit systemd overlayfs
 
-DATA_PARTITION_OVERLAY_WRITABLE_PATHS ?= "/etc/ssh /etc/NetworkManager/system-connections"
+DATA_PARTITION_OVERLAY_WRITABLE_PATHS ?= "/etc/ssh /etc/NetworkManager/system-connections /etc/systemd/network"
 OVERLAYFS_WRITABLE_PATHS[data] = "${DATA_PARTITION_OVERLAY_WRITABLE_PATHS}"
 
 SRC_URI = " \
@@ -24,6 +24,7 @@ FILES:${PN} += " \
     ${nonarch_libdir}/repart.d/ \
     ${systemd_system_unitdir}/sshdgenkeys.service.d/ \
     ${systemd_system_unitdir}/NetworkManager.service.d/ \
+    ${systemd_system_unitdir}/systemd-networkd.service.d/ \
     /data \
 "
 
@@ -41,6 +42,10 @@ do_install() {
     install -d ${D}${systemd_system_unitdir}/NetworkManager.service.d
     install -m 0644 ${S}/10-data-overlays.conf \
         ${D}${systemd_system_unitdir}/NetworkManager.service.d/
+
+    install -d ${D}${systemd_system_unitdir}/systemd-networkd.service.d
+    install -m 0644 ${S}/10-data-overlays.conf \
+        ${D}${systemd_system_unitdir}/systemd-networkd.service.d/
 
     install -d ${D}/data
 }

--- a/layers/meta-tegrademo/recipes-demo/data-partition/data-partition_1.0.bb
+++ b/layers/meta-tegrademo/recipes-demo/data-partition/data-partition_1.0.bb
@@ -1,0 +1,46 @@
+SUMMARY = "First-boot /data partition creation, mount, and overlayfs setup"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+inherit systemd overlayfs
+
+DATA_PARTITION_OVERLAY_WRITABLE_PATHS ?= "/etc/ssh /etc/NetworkManager/system-connections"
+OVERLAYFS_WRITABLE_PATHS[data] = "${DATA_PARTITION_OVERLAY_WRITABLE_PATHS}"
+
+SRC_URI = " \
+    file://10-data-overlays.conf \
+    file://50-data.conf \
+    file://data.mount \
+"
+
+S = "${UNPACKDIR}"
+
+RDEPENDS:${PN} = "systemd"
+
+SYSTEMD_SERVICE:${PN} = "data.mount"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+FILES:${PN} += " \
+    ${nonarch_libdir}/repart.d/ \
+    ${systemd_system_unitdir}/sshdgenkeys.service.d/ \
+    ${systemd_system_unitdir}/NetworkManager.service.d/ \
+    /data \
+"
+
+do_install() {
+    install -d ${D}${nonarch_libdir}/repart.d
+    install -m 0644 ${S}/50-data.conf ${D}${nonarch_libdir}/repart.d/
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${S}/data.mount ${D}${systemd_system_unitdir}/
+
+    install -d ${D}${systemd_system_unitdir}/sshdgenkeys.service.d
+    install -m 0644 ${S}/10-data-overlays.conf \
+        ${D}${systemd_system_unitdir}/sshdgenkeys.service.d/
+
+    install -d ${D}${systemd_system_unitdir}/NetworkManager.service.d
+    install -m 0644 ${S}/10-data-overlays.conf \
+        ${D}${systemd_system_unitdir}/NetworkManager.service.d/
+
+    install -d ${D}/data
+}

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-common.inc
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-common.inc
@@ -9,4 +9,21 @@ CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-base packagegroup-demo-basetests"
 CORE_IMAGE_BASE_INSTALL += "${@'packagegroup-demo-systemd' if d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd' else ''}"
 TOOLCHAIN_HOST_TASK += "nativesdk-packagegroup-cuda-sdk-host"
 
-inherit nopackages
+inherit nopackages l4t_version
+
+configure_issue () {
+    cat > ${IMAGE_ROOTFS}${sysconfdir}/issue << ISSUE_EOF
+\e{bold}\e{green}\S{NAME}\e{reset}
+
+  \e{cyan}Hostname\e{reset}  :  \e{bold}\n\e{reset}
+  \e{cyan}Kernel\e{reset}    :  \s \r
+  \e{cyan}L4T\e{reset}       :  R${L4T_VERSION}
+  \e{cyan}Version\e{reset}   :  \S{VERSION}
+  \e{cyan}eth0\e{reset}      :  \4{eth0}
+  \e{cyan}wlan0\e{reset}     :  \4{wlan0}
+
+\e{green}Image '${PN}' ready on \l\e{reset}
+
+ISSUE_EOF
+}
+ROOTFS_POSTPROCESS_COMMAND += "configure_issue"

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-reference.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-reference.bb
@@ -67,10 +67,13 @@ CORE_IMAGE_BASE_INSTALL += " \
 CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-vulkantests"
 
 # Virtualization packages: docker, nvidia-container-toolkit
+# docker-data-conf and containerd-data-conf redirect storage to /data (requires data-partition)
 CORE_IMAGE_BASE_INSTALL += " \
     docker \
     nvidia-container-toolkit \
     docker-registry-config \
+    docker-data-conf \
+    containerd-data-conf \
 "
 
 # shadow-securetty populates /etc/securetty from SERIAL_CONSOLES at build time

--- a/layers/meta-tegrademo/recipes-demo/images/demo-image-reference.bb
+++ b/layers/meta-tegrademo/recipes-demo/images/demo-image-reference.bb
@@ -1,0 +1,77 @@
+DESCRIPTION = "Tegra reference image with comprehensive test tools for QA validation. \
+Includes all publicly available test packages from OE/Yocto recipes"
+
+require demo-image-common.inc
+
+inherit features_check
+
+REQUIRED_DISTRO_FEATURES = "opengl wayland wifi x11 vulkan virtualization overlayfs pulseaudio"
+
+IMAGE_FEATURES += "hwcodecs x11-base x11-sato container-registry"
+
+SYSTEMD_DEFAULT_TARGET = "graphical.target"
+
+# Other convenient support packages
+CORE_IMAGE_BASE_INSTALL += " \
+    l4t-usb-device-mode \
+    data-partition \
+"
+
+# System utilities: GNU userland, hardware inspection, networking, monitoring
+CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-sysutils"
+
+# NetworkManager with WiFi and TUI for headless configuration
+# networkmanager-nmtui is pulled in via RRECOMMENDS when the nmtui PACKAGECONFIG is active
+CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-networkmanager"
+
+# Weston compositor (manual launch only, no weston-init service)
+# weston RRECOMMENDS weston-init; suppress it so the service does not auto-start
+# and conflict with the X11 session.
+BAD_RECOMMENDATIONS += "weston-init"
+CORE_IMAGE_BASE_INSTALL += " \
+    weston \
+    packagegroup-demo-westontests \
+"
+
+# EGL-device / headless multimedia tests (no window manager required)
+CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-egltests"
+
+# Additional public test tools: v4l-utils, lmbench, iperf3, rt-tests, perf, glmark2, kmscube
+CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-reftests"
+
+# Extra kernel modules for reference image test coverage (crypto self-test, UVC webcams)
+CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-refmodules"
+
+# Tegra-specific test packages (from public L4T source in meta-tegra / meta-tegra-community)
+CORE_IMAGE_BASE_INSTALL += " \
+    cuda-libraries \
+    tegra-cuda-utils \
+    cudnn-tests \
+    tensorrt-tests \
+    vpi4-tests \
+    vpi4-samples \
+    tegra-tools-dram-info \
+    pva-sdk \
+    nsight-systems \
+"
+
+# X11 packages: argus-samples, mesa-demos, l4t-graphics-demos-x11, SIPL, MMAPI
+CORE_IMAGE_BASE_INSTALL += " \
+    packagegroup-demo-x11tests \
+    jetson-sipl-api \
+    jetson-sipl-api-drivers \
+    tegra-mmapi-tests \
+"
+
+# Vulkan packages: vulkan-tools, tegra-libraries-vulkan
+CORE_IMAGE_BASE_INSTALL += "packagegroup-demo-vulkantests"
+
+# Virtualization packages: docker, nvidia-container-toolkit
+CORE_IMAGE_BASE_INSTALL += " \
+    docker \
+    nvidia-container-toolkit \
+    docker-registry-config \
+"
+
+# shadow-securetty populates /etc/securetty from SERIAL_CONSOLES at build time
+CORE_IMAGE_BASE_INSTALL += "shadow"

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-networkmanager.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-networkmanager.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "NetworkManager with WiFi support for images that use it as the primary network manager"
+
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    networkmanager \
+    networkmanager-wifi \
+"
+
+RDEPENDS:${PN}:append:tegra264 = " \
+    networkmanager-config \
+"

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-refmodules.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-refmodules.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Extra kernel modules for Tegra reference image test coverage"
+
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    kernel-module-tcrypt \
+    kernel-module-uvcvideo \
+"
+
+# Built into linux-yocto's default config rather than modules; recommend
+# instead of require so kernels that do module them (e.g. noble) still get them.
+RRECOMMENDS:${PN} = " \
+    kernel-module-ccm \
+    kernel-module-cmac \
+    kernel-module-ctr \
+    kernel-module-gcm \
+    kernel-module-ghash-generic \
+    kernel-module-xts \
+"

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-reftests.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-reftests.bb
@@ -10,7 +10,6 @@ RDEPENDS:${PN} = " \
     perf \
     rt-tests \
     stress-ng \
-    kernel-module-uvcvideo \
     v4l-utils \
     glmark2 \
     kmscube \

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-reftests.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-reftests.bb
@@ -1,0 +1,36 @@
+DESCRIPTION = "Additional reference test tools for Tegra QA validation"
+
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+    iperf3 \
+    lmbench \
+    perf \
+    rt-tests \
+    stress-ng \
+    kernel-module-uvcvideo \
+    v4l-utils \
+    glmark2 \
+    kmscube \
+    tegra-vulkan-sc-samples \
+    tegra-libraries-camera-nvraw \
+    nvgstipctestapp \
+    gstreamer1.0-plugins-base-opus \
+    gstreamer1.0-libav \
+    python3-jetson-io \
+    fio \
+    yavta \
+    dhrystone \
+    schbench \
+    stream \
+    python3-pytest \
+    sysbench \
+    cpuburn-arm \
+    stressapptest \
+    memtester \
+    tinymembench \
+    iozone3 \
+    cpupower \
+"

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-systemd.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-systemd.bb
@@ -10,3 +10,7 @@ RDEPENDS:${PN} = " \
     less \
     systemd-analyze \
 "
+
+RDEPENDS:${PN}:append:tegra264 = " \
+    systemd-networkd-config \
+"

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-sysutils.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-sysutils.bb
@@ -1,0 +1,80 @@
+DESCRIPTION = "System utilities for the Tegra reference image: GNU userland, hardware inspection, and system monitoring"
+
+LICENSE = "MIT"
+
+inherit packagegroup
+
+# GNU userland — replaces busybox applets not covered by coreutils alone
+RDEPENDS:${PN} = " \
+    coreutils \
+    findutils \
+    sed \
+    grep \
+    gawk \
+    bash \
+    tar \
+    gzip \
+    bzip2 \
+    xz \
+    diffutils \
+    patch \
+    which \
+    bc \
+    util-linux \
+    file \
+    vim \
+    minicom \
+"
+
+# Networking
+RDEPENDS:${PN} += " \
+    curl \
+    rsync \
+    iproute2 \
+    iproute2-ss \
+    iproute2-tc \
+    iproute2-bridge \
+    iproute2-nstat \
+    iproute2-devlink \
+    iputils \
+    net-tools \
+    ethtool \
+    iw \
+"
+
+# Hardware inspection
+RDEPENDS:${PN} += " \
+    pciutils \
+    usbutils \
+    i2c-tools \
+    libgpiod-tools \
+    spidev-test \
+    can-utils \
+    dmidecode \
+    hdparm \
+    nvme-cli \
+    ufs-utils \
+    devmem2 \
+    lua \
+"
+
+# System monitoring and admin
+RDEPENDS:${PN} += " \
+    lsof \
+    sysstat \
+    e2fsprogs \
+    psmisc \
+    valgrind \
+    python3-pip \
+    usleep \
+"
+
+# Audio: PulseAudio daemon, pactl and other control utilities, full ALSA utils suite
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio-server pulseaudio-misc pulseaudio-pactl', '', d)}"
+RDEPENDS:${PN} += "alsa-utils"
+
+# RT kernel tools (chrt and taskset come from util-linux above)
+RDEPENDS:${PN} += " \
+    tuna \
+    trace-cmd \
+"

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-vulkantests.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-vulkantests.bb
@@ -7,4 +7,5 @@ inherit packagegroup
 RDEPENDS:${PN} = " \
     vulkan-tools \
     tegra-libraries-vulkan \
+    vkcube \
 "

--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-x11tests.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-x11tests.bb
@@ -5,10 +5,13 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
+    setxkbmap \
+    xterm \
     argus-samples \
     cuda-samples \
     gstreamer-tests \
     l4t-graphics-demos-x11 \
     mesa-demos \
     nvgstapps \
+    rendercheck \
 "

--- a/layers/meta-tegrademo/recipes-graphics/xinput-calibrator/xinput-calibrator_%.bbappend
+++ b/layers/meta-tegrademo/recipes-graphics/xinput-calibrator/xinput-calibrator_%.bbappend
@@ -1,0 +1,7 @@
+# Suppress autostart on non-touchscreen machines; Xsession.d/30xinput_calibrate.sh
+# already gates on HAVE_TOUCHSCREEN correctly.
+do_install:append() {
+    if ${@bb.utils.contains('MACHINE_FEATURES', 'touchscreen', 'false', 'true', d)}; then
+        rm -f ${D}${sysconfdir}/xdg/autostart/xinput_calibrator.desktop
+    fi
+}


### PR DESCRIPTION
Updates largely in support of the JP 7.2.1 integration in https://github.com/OE4T/meta-tegra/pull/2323

This is a new distro and corresponding image for tegrademo with a few different opinions about the contents of a demo image. The new demo-image-reference is designed for a more "out of the box" experience, rather than a demonstration regarding how to customize or put together your own image. Builds based on this image are intended to be used in a getting started capacity as well as for internal QA testing at NVIDIA.

A few of the different opinions, including but not limited to:

- Default to the RT variant of the vendor kernel
- Additional distro features for more coverage (notably pulseaudio, bluetooth, and wayland on top of X11)
- Persistent storage and overlayfs for data survival between swupdates
- Default support for swupdate
- Use of networkmanager and rather than connman (for easier to use nmtui and nm-applet tools)
- A number of additional system benchmarking and analysis tools
- A number of additional demos and samples for various components

At one point maybe the demo-image-reference would have been buildable outside of tegrademo-extended, but making it generic enough and being able to handle things like overlayfs proved more trouble than it is worth, so the two distro targets maintain their different lists of applicable images.

There shouldn't be anything here specific to 7.2.1, but it will be taken out of draft at the same point, because the testing along side them is coincidental.