### PR TITLE
packagegroup-demo-base: replace gptfdisk with util-linux fdisk tools

### DIFF
--- a/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-base.bb
+++ b/layers/meta-tegrademo/recipes-demo/packagegroups/packagegroup-demo-base.bb
@@ -5,9 +5,10 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
-    gptfdisk \
     procps \
     sshfs-fuse \
     strace \
     tegra-tools-tegrastats \
+    util-linux-fdisk \
+    util-linux-sfdisk \
 "


### PR DESCRIPTION
oe-core removed the gptfdisk recipe in commit 188d84bcc136 ("gptfdisk: remove recipe"), so demo-image-base no longer builds:

  ERROR: Nothing RPROVIDES 'gptfdisk' (but .../packagegroup-demo-base.bb
  RDEPENDS on or otherwise requires it)

Pull in util-linux-fdisk and util-linux-sfdisk instead to keep a GPT-capable partitioning tool on the demo images.